### PR TITLE
feat: forgot password - OTP verification and reset password flow

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -1,5 +1,3 @@
-// lib/core/di/injection.dart
-
 import 'package:dio/dio.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
@@ -13,7 +11,9 @@ import 'package:read_buddy_app/features/bookcrud/domain/usecases/search_location
 import 'package:read_buddy_app/features/bookcrud/presentation/cubit/cubit/location_cubit.dart';
 
 // Core
-import '../../features/questionaries/data/repositories/question_repository_impl.dart';
+import '../../features/profile/data/datasource/profile_remote_data_source.dart';
+import '../../features/profile/domain/usecases/get_profile.dart';
+import '../../features/profile/domain/usecases/update_user_avatar.dart';
 import '../network/dio_client.dart';
 import '../utils/secure_storage_utils.dart';
 
@@ -25,14 +25,17 @@ import '../../features/auth/domain/usecases/register_user_usecase.dart';
 import '../../features/auth/domain/usecases/sign_in.dart';
 import '../../features/auth/domain/usecases/sign_in_with_google.dart';
 import '../../features/auth/domain/usecases/verify_email_usecase.dart';
+import '../../features/auth/domain/usecases/send_otp_usecase.dart';
+import '../../features/auth/domain/usecases/verify_reset_otp_usecase.dart';
+import '../../features/auth/domain/usecases/change_password_usecase.dart';
 import '../../features/auth/presentation/blocs/google_sign_in/google_sign_in_bloc.dart';
 import '../../features/auth/presentation/blocs/sign_in/sign_in_bloc.dart';
 import '../../features/auth/presentation/blocs/sign_up/sign_up_bloc.dart';
 
 // Profile
-import '../../features/profile/data/remotesource/profile_remote_data_source.dart';
 import '../../features/profile/data/repositories/profile_repository_impl.dart';
 import '../../features/profile/domain/repositories/profile_repository.dart';
+
 import '../../features/profile/domain/usecases/update_profile_usecase.dart';
 import '../../features/profile/presentation/blocs/profile_bloc.dart';
 
@@ -79,6 +82,7 @@ import '../../features/banner/presentation/bloc/banner_bloc.dart';
 
 // Questionaries
 import '../../features/questionaries/data/datasources/onboarding_remote_datasource.dart';
+import '../../features/questionaries/data/repositories/question_repository_impl.dart';
 import '../../features/questionaries/domain/repositories/onboarding_repository.dart';
 import '../../features/questionaries/domain/usecases/get_questions.dart';
 import '../../features/questionaries/domain/usecases/set_preferences.dart';
@@ -89,19 +93,19 @@ import '../../features/questionaries/presentations/bloc/on_boarding_bloc.dart';
 
 // Question CRUD (Admin)
 import '../../features/question_crud/data/datasources/question_remote_datasource.dart'
-    as QuestionCrudData;
+as QuestionCrudDataSource;
 import '../../features/question_crud/data/repositories/question_repository_impl.dart'
-    as QuestionCrudData;
+as QuestionCrudRepo;
 import '../../features/question_crud/domain/repositories/question_repository.dart'
-    as QuestionCrudDomain;
+as QuestionCrudDomain;
 import '../../features/question_crud/domain/usecases/get_questions.dart'
-    as QuestionCrudUseCases;
+as QuestionCrudUseCases;
 import '../../features/question_crud/domain/usecases/add_question.dart'
-    as QuestionCrudUseCases;
+as QuestionCrudUseCases;
 import '../../features/question_crud/domain/usecases/update_question.dart'
-    as QuestionCrudUseCases;
+as QuestionCrudUseCases;
 import '../../features/question_crud/domain/usecases/delete_question.dart'
-    as QuestionCrudUseCases;
+as QuestionCrudUseCases;
 
 final getIt = GetIt.instance;
 
@@ -133,55 +137,58 @@ void _registerUtils() {
 void _registerDataSources() {
   // Auth
   getIt.registerLazySingleton<AuthRemoteDataSource>(
-    () => AuthRemoteDataSourceImpl(dio: getIt<Dio>()),
+        () => AuthRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
-  // Profile
+  // Profile — fixed: pass real secureStorage instead of null
   getIt.registerLazySingleton<ProfileRemoteDataSource>(
-    () => ProfileRemoteDataSourceImpl(dio: getIt<Dio>()),
+        () => ProfileRemoteDataSourceImpl(
+      dio: getIt<Dio>(),
+      secureStorage: getIt<SecureStorageUtil>(), // ← FIXED
+    ),
   );
 
   // Books
   getIt.registerLazySingleton<BookRemoteDataSource>(
-    () => BookRemoteDataSourceImpl(dio: getIt<Dio>()),
+        () => BookRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Book CRUD
   getIt.registerLazySingleton<BookCrudRemoteDataSource>(
-    () => BookCrudRemoteDataSourceImpl(dio: getIt<Dio>()),
+        () => BookCrudRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // User
   getIt.registerLazySingleton<UserRemoteResources>(
-    () => UserRemoteResourcesImpl(dio: getIt<Dio>()),
+        () => UserRemoteResourcesImpl(dio: getIt<Dio>()),
   );
 
   // Search Location
   getIt.registerLazySingleton<SearchLocationRemoteResources>(
-    () => SearchLocationRemoteResourcesImpl(dio: getIt<Dio>()),
+        () => SearchLocationRemoteResourcesImpl(dio: getIt<Dio>()),
   );
 
   // Category CRUD
   getIt.registerLazySingleton<CategoryRemoteDataSource>(
-    () => CategoryRemoteDataSourceImpl(dio: getIt<Dio>()),
+        () => CategoryRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Banner
   getIt.registerLazySingleton<BannerRemoteDataSource>(
-    () => BannerRemoteDataSourceImpl(dio: getIt<Dio>()),
+        () => BannerRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Questionaries
   getIt.registerLazySingleton<OnboardingRemoteDataSource>(
-    () => OnboardingRemoteDataSourceImpl(
+        () => OnboardingRemoteDataSourceImpl(
       dio: getIt<Dio>(),
       secureStorage: getIt<SecureStorageUtil>(),
     ),
   );
 
   // Question CRUD (Admin)
-  getIt.registerLazySingleton<QuestionCrudData.QuestionRemoteDataSource>(
-    () => QuestionCrudData.QuestionRemoteDataSource(
+  getIt.registerLazySingleton<QuestionCrudDataSource.QuestionRemoteDataSource>(
+        () => QuestionCrudDataSource.QuestionRemoteDataSource(
       getIt<Dio>(),
       getIt<SecureStorageUtil>(),
     ),
@@ -194,53 +201,54 @@ void _registerDataSources() {
 void _registerRepositories() {
   // Auth
   getIt.registerLazySingleton<AuthRepository>(
-    () => AuthRepositoryImpl(getIt<AuthRemoteDataSource>()),
+        () => AuthRepositoryImpl(getIt<AuthRemoteDataSource>()),
   );
 
   // Profile
   getIt.registerLazySingleton<ProfileRepository>(
-    () => ProfileRepositoryImpl(getIt<ProfileRemoteDataSource>()),
+        () => ProfileRepositoryImpl(getIt<ProfileRemoteDataSource>()),
   );
 
   // Books
   getIt.registerLazySingleton<BookRepository>(
-    () => BookRepositoryImpl(getIt<BookRemoteDataSource>()),
+        () => BookRepositoryImpl(getIt<BookRemoteDataSource>()),
   );
 
   // Book CRUD
   getIt.registerLazySingleton<BookCrudRepository>(
-    () => BookCrudRepositoryImpl(getIt<BookCrudRemoteDataSource>()),
+        () => BookCrudRepositoryImpl(getIt<BookCrudRemoteDataSource>()),
   );
 
   // User
   getIt.registerLazySingleton<UserRepository>(
-    () => UserRepositoryImpl(getIt<UserRemoteResources>()),
+        () => UserRepositoryImpl(getIt<UserRemoteResources>()),
   );
 
   // Search Location
   getIt.registerLazySingleton<SearchLocationRepository>(
-    () => SearchLocationRepoImpl(getIt<SearchLocationRemoteResources>()),
+        () => SearchLocationRepoImpl(getIt<SearchLocationRemoteResources>()),
   );
 
   // Category CRUD
   getIt.registerLazySingleton<CategoryRepository>(
-    () => CategoryRepositoryImpl(getIt<CategoryRemoteDataSource>()),
+        () => CategoryRepositoryImpl(getIt<CategoryRemoteDataSource>()),
   );
 
   // Banner
   getIt.registerLazySingleton<BannerRepository>(
-    () => BannerRepoImpl(remoteDataSource: getIt<BannerRemoteDataSource>()),
+        () => BannerRepoImpl(remoteDataSource: getIt<BannerRemoteDataSource>()),
   );
 
   // Questionaries
   getIt.registerLazySingleton<OnboardingRepository>(
-    () => OnboardingRepositoryImpl(getIt<OnboardingRemoteDataSource>()),
+        () => OnboardingRepositoryImpl(getIt<OnboardingRemoteDataSource>()),
   );
 
   // Question CRUD (Admin)
   getIt.registerLazySingleton<QuestionCrudDomain.QuestionRepository>(
-    () => QuestionCrudData.QuestionRepositoryImpl(
-        getIt<QuestionCrudData.QuestionRemoteDataSource>()),
+        () => QuestionCrudRepo.QuestionRepositoryImpl(
+      getIt<QuestionCrudDataSource.QuestionRemoteDataSource>(),
+    ),
   );
 }
 
@@ -251,71 +259,61 @@ void _registerUseCases() {
   // Auth
   getIt.registerLazySingleton(() => SignIn(getIt<AuthRepository>()));
   getIt.registerLazySingleton(() => SignInWithGoogle(getIt<AuthRepository>()));
-  getIt.registerLazySingleton(
-      () => RegisterUserUseCase(getIt<AuthRepository>()));
-  getIt
-      .registerLazySingleton(() => VerifyEmailUseCase(getIt<AuthRepository>()));
+  getIt.registerLazySingleton(() => RegisterUserUseCase(getIt<AuthRepository>()));
+  getIt.registerLazySingleton(() => VerifyEmailUseCase(getIt<AuthRepository>()));
+  getIt.registerLazySingleton(() => SendOtpUseCase(getIt<AuthRepository>()));
+  getIt.registerLazySingleton(() => VerifyResetOtpUseCase(getIt<AuthRepository>()));
+  getIt.registerLazySingleton(() => ChangePasswordUseCase(getIt<AuthRepository>()));
 
-  // Profile
-  getIt.registerLazySingleton(
-      () => UpdateProfileUseCase(getIt<ProfileRepository>()));
+  // Profile — added GetProfileUseCase and UpdateAvatarUseCase
+  getIt.registerLazySingleton(() => GetProfileUseCase(getIt<ProfileRepository>()));   // ← NEW
+  getIt.registerLazySingleton(() => UpdateAvatarUseCase(getIt<ProfileRepository>())); // ← NEW
+  getIt.registerLazySingleton(() => UpdateProfileUseCase(getIt<ProfileRepository>()));
 
   // Books
   getIt.registerLazySingleton(() => GetBooks(getIt<BookRepository>()));
 
   // Book CRUD
-  getIt.registerLazySingleton(
-      () => SearchBookUsecase(getIt<BookCrudRepository>()));
-  getIt
-      .registerLazySingleton(() => AddBookUsecase(getIt<BookCrudRepository>()));
-  getIt.registerLazySingleton(
-      () => GetBooksUsecase(getIt<BookCrudRepository>()));
-  getIt.registerLazySingleton(
-      () => GetBookByIdUsecase(getIt<BookCrudRepository>()));
-  getIt.registerLazySingleton(
-      () => UpdateBookUsecase(getIt<BookCrudRepository>()));
-  getIt.registerLazySingleton(
-      () => DeleteBookusecase(getIt<BookCrudRepository>()));
+  getIt.registerLazySingleton(() => SearchBookUsecase(getIt<BookCrudRepository>()));
+  getIt.registerLazySingleton(() => AddBookUsecase(getIt<BookCrudRepository>()));
+  getIt.registerLazySingleton(() => GetBooksUsecase(getIt<BookCrudRepository>()));
+  getIt.registerLazySingleton(() => GetBookByIdUsecase(getIt<BookCrudRepository>()));
+  getIt.registerLazySingleton(() => UpdateBookUsecase(getIt<BookCrudRepository>()));
+  getIt.registerLazySingleton(() => DeleteBookusecase(getIt<BookCrudRepository>()));
 
   // User
-  getIt
-      .registerLazySingleton(() => GetUserListUseCase(getIt<UserRepository>()));
+  getIt.registerLazySingleton(() => GetUserListUseCase(getIt<UserRepository>()));
 
   // Search Location
   getIt.registerLazySingleton(
-      () => SearchLocationUsecase(getIt<SearchLocationRepository>()));
+          () => SearchLocationUsecase(getIt<SearchLocationRepository>()));
 
   // Category CRUD
+  getIt.registerLazySingleton(() => AddCategoryUsecase(getIt<CategoryRepository>()));
   getIt.registerLazySingleton(
-      () => AddCategoryUsecase(getIt<CategoryRepository>()));
+          () => DeleteCategoryUsecase(getIt<CategoryRepository>()));
   getIt.registerLazySingleton(
-      () => DeleteCategoryUsecase(getIt<CategoryRepository>()));
+          () => GetCategoriesUsecase(getIt<CategoryRepository>()));
   getIt.registerLazySingleton(
-      () => GetCategoriesUsecase(getIt<CategoryRepository>()));
-  getIt.registerLazySingleton(
-      () => UpdateCategoryUsecase(getIt<CategoryRepository>()));
+          () => UpdateCategoryUsecase(getIt<CategoryRepository>()));
 
   // Banner
-  getIt
-      .registerLazySingleton(() => GetBannerUsecase(getIt<BannerRepository>()));
-  getIt.registerLazySingleton(
-      () => CreateBannerUsecase(getIt<BannerRepository>()));
-  getIt.registerLazySingleton(
-      () => UpdateBannerUsecase(getIt<BannerRepository>()));
-  getIt.registerLazySingleton(
-      () => DeleteBannerUsecase(getIt<BannerRepository>()));
+  getIt.registerLazySingleton(() => GetBannerUsecase(getIt<BannerRepository>()));
+  getIt.registerLazySingleton(() => CreateBannerUsecase(getIt<BannerRepository>()));
+  getIt.registerLazySingleton(() => UpdateBannerUsecase(getIt<BannerRepository>()));
+  getIt.registerLazySingleton(() => DeleteBannerUsecase(getIt<BannerRepository>()));
 
   // Questionaries
   getIt.registerLazySingleton(
-      () => GetQuestionsUseCase(getIt<OnboardingRepository>()));
+          () => GetQuestionsUseCase(getIt<OnboardingRepository>()));
   getIt.registerLazySingleton(
-      () => SetPreferencesUseCase(getIt<OnboardingRepository>()));
+          () => SetPreferencesUseCase(getIt<OnboardingRepository>()));
   getIt.registerLazySingleton(
-      () => UpdatePreferencesUseCase(getIt<OnboardingRepository>()));
+          () => UpdatePreferencesUseCase(getIt<OnboardingRepository>()));
   getIt.registerLazySingleton(
-      () => DeletePreferencesUseCase(getIt<OnboardingRepository>()));
+          () => DeletePreferencesUseCase(getIt<OnboardingRepository>()));
   getIt.registerLazySingleton(
-      () => SetOnboardingStatusUseCase(getIt<OnboardingRepository>()));
+          () => SetOnboardingStatusUseCase(getIt<OnboardingRepository>()));
 
   // Question CRUD (Admin)
   getIt.registerLazySingleton(() => QuestionCrudUseCases.GetQuestions(
@@ -333,57 +331,63 @@ void _registerUseCases() {
 // ========================================
 void _registerBlocs() {
   // Auth
-  getIt.registerLazySingleton(() => SignInBloc(getIt<SignIn>()));
-  getIt
-      .registerLazySingleton(() => GoogleSignInBloc(getIt<SignInWithGoogle>()));
+  getIt.registerLazySingleton(() => SignInBloc(
+    getIt<SignIn>(),
+    getIt<SendOtpUseCase>(),
+    getIt<VerifyResetOtpUseCase>(),
+    getIt<ChangePasswordUseCase>(),
+  ));
+  getIt.registerLazySingleton(() => GoogleSignInBloc(getIt<SignInWithGoogle>()));
   getIt.registerLazySingleton(() => SignUpBloc(
-        getIt<RegisterUserUseCase>(),
-        getIt<VerifyEmailUseCase>(),
-      ));
+    getIt<RegisterUserUseCase>(),
+    getIt<VerifyEmailUseCase>(),
+  ));
 
-  // Profile
-  getIt.registerLazySingleton(() => ProfileBloc(
-        getIt<SecureStorageUtil>(),
-        getIt<UpdateProfileUseCase>(),
-      ));
+  // Profile — fixed: added all 4 required constructor args
+  getIt.registerFactory(() => ProfileBloc(
+    getIt<SecureStorageUtil>(),
+    getIt<GetProfileUseCase>(),    // ← NEW
+    getIt<UpdateAvatarUseCase>(),  // ← NEW
+    getIt<UpdateProfileUseCase>(),
+  ));
 
   // Books
   getIt.registerLazySingleton(() => BookBloc(getIt<GetBooks>()));
 
   // Book CRUD
   getIt.registerLazySingleton(() => BookCrudBloc(
-        searchBooks: getIt<SearchBookUsecase>(),
-        addBookCrud: getIt<AddBookUsecase>(),
-        getBooksCrud: getIt<GetBooksUsecase>(),
-        getBookByIdCrud: getIt<GetBookByIdUsecase>(),
-        updateBookCrud: getIt<UpdateBookUsecase>(),
-        deleteBookCrud: getIt<DeleteBookusecase>(),
-      ));
+    searchBooks: getIt<SearchBookUsecase>(),
+    addBookCrud: getIt<AddBookUsecase>(),
+    getBooksCrud: getIt<GetBooksUsecase>(),
+    getBookByIdCrud: getIt<GetBookByIdUsecase>(),
+    updateBookCrud: getIt<UpdateBookUsecase>(),
+    deleteBookCrud: getIt<DeleteBookusecase>(),
+  ));
 
   // Category CRUD
   getIt.registerLazySingleton(() => CategoryBloc(
-        getCategories: getIt<GetCategoriesUsecase>(),
-        addCategory: getIt<AddCategoryUsecase>(),
-        updateCategory: getIt<UpdateCategoryUsecase>(),
-        deleteCategory: getIt<DeleteCategoryUsecase>(),
-      ));
+    getCategories: getIt<GetCategoriesUsecase>(),
+    addCategory: getIt<AddCategoryUsecase>(),
+    updateCategory: getIt<UpdateCategoryUsecase>(),
+    deleteCategory: getIt<DeleteCategoryUsecase>(),
+  ));
 
   // Banner
   getIt.registerLazySingleton(() => BannerBloc(
-        getBannerUsecase: getIt<GetBannerUsecase>(),
-        createBannerUsecase: getIt<CreateBannerUsecase>(),
-        updateBannerUsecase: getIt<UpdateBannerUsecase>(),
-        deleteBannerUsecase: getIt<DeleteBannerUsecase>(),
-      ));
+    getBannerUsecase: getIt<GetBannerUsecase>(),
+    createBannerUsecase: getIt<CreateBannerUsecase>(),
+    updateBannerUsecase: getIt<UpdateBannerUsecase>(),
+    deleteBannerUsecase: getIt<DeleteBannerUsecase>(),
+  ));
 
-  // Questionaries — registerFactory for fresh instance per screen
+  // Questionaries
   getIt.registerFactory(() => OnboardingBloc(
-        getQuestionsUseCase: getIt<GetQuestionsUseCase>(),
-        setPreferencesUseCase: getIt<SetPreferencesUseCase>(),
-        updatePreferencesUseCase: getIt<UpdatePreferencesUseCase>(),
-        deletePreferencesUseCase: getIt<DeletePreferencesUseCase>(),
-        setOnboardingStatusUseCase: getIt<SetOnboardingStatusUseCase>(),
-      ));
+    getQuestionsUseCase: getIt<GetQuestionsUseCase>(),
+    setPreferencesUseCase: getIt<SetPreferencesUseCase>(),
+    updatePreferencesUseCase: getIt<UpdatePreferencesUseCase>(),
+    deletePreferencesUseCase: getIt<DeletePreferencesUseCase>(),
+    setOnboardingStatusUseCase: getIt<SetOnboardingStatusUseCase>(),
+  ));
 }
 
 // ========================================
@@ -391,6 +395,5 @@ void _registerBlocs() {
 // ========================================
 void _registerCubits() {
   getIt.registerLazySingleton(() => UserCubit(getIt<GetUserListUseCase>()));
-  getIt.registerLazySingleton(
-      () => LocationCubit(getIt<SearchLocationUsecase>()));
+  getIt.registerLazySingleton(() => LocationCubit(getIt<SearchLocationUsecase>()));
 }

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -11,9 +11,6 @@ import 'package:read_buddy_app/features/bookcrud/domain/usecases/search_location
 import 'package:read_buddy_app/features/bookcrud/presentation/cubit/cubit/location_cubit.dart';
 
 // Core
-import '../../features/profile/data/datasource/profile_remote_data_source.dart';
-import '../../features/profile/domain/usecases/get_profile.dart';
-import '../../features/profile/domain/usecases/update_user_avatar.dart';
 import '../network/dio_client.dart';
 import '../utils/secure_storage_utils.dart';
 
@@ -31,13 +28,6 @@ import '../../features/auth/domain/usecases/change_password_usecase.dart';
 import '../../features/auth/presentation/blocs/google_sign_in/google_sign_in_bloc.dart';
 import '../../features/auth/presentation/blocs/sign_in/sign_in_bloc.dart';
 import '../../features/auth/presentation/blocs/sign_up/sign_up_bloc.dart';
-
-// Profile
-import '../../features/profile/data/repositories/profile_repository_impl.dart';
-import '../../features/profile/domain/repositories/profile_repository.dart';
-
-import '../../features/profile/domain/usecases/update_profile_usecase.dart';
-import '../../features/profile/presentation/blocs/profile_bloc.dart';
 
 // Books
 import '../../features/books/data/datasources/book_remote_data_source.dart';
@@ -93,19 +83,19 @@ import '../../features/questionaries/presentations/bloc/on_boarding_bloc.dart';
 
 // Question CRUD (Admin)
 import '../../features/question_crud/data/datasources/question_remote_datasource.dart'
-as QuestionCrudDataSource;
+    as QuestionCrudDataSource;
 import '../../features/question_crud/data/repositories/question_repository_impl.dart'
-as QuestionCrudRepo;
+    as QuestionCrudRepo;
 import '../../features/question_crud/domain/repositories/question_repository.dart'
-as QuestionCrudDomain;
+    as QuestionCrudDomain;
 import '../../features/question_crud/domain/usecases/get_questions.dart'
-as QuestionCrudUseCases;
+    as QuestionCrudUseCases;
 import '../../features/question_crud/domain/usecases/add_question.dart'
-as QuestionCrudUseCases;
+    as QuestionCrudUseCases;
 import '../../features/question_crud/domain/usecases/update_question.dart'
-as QuestionCrudUseCases;
+    as QuestionCrudUseCases;
 import '../../features/question_crud/domain/usecases/delete_question.dart'
-as QuestionCrudUseCases;
+    as QuestionCrudUseCases;
 
 final getIt = GetIt.instance;
 
@@ -137,50 +127,42 @@ void _registerUtils() {
 void _registerDataSources() {
   // Auth
   getIt.registerLazySingleton<AuthRemoteDataSource>(
-        () => AuthRemoteDataSourceImpl(dio: getIt<Dio>()),
-  );
-
-  // Profile — fixed: pass real secureStorage instead of null
-  getIt.registerLazySingleton<ProfileRemoteDataSource>(
-        () => ProfileRemoteDataSourceImpl(
-      dio: getIt<Dio>(),
-      secureStorage: getIt<SecureStorageUtil>(), // ← FIXED
-    ),
+    () => AuthRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Books
   getIt.registerLazySingleton<BookRemoteDataSource>(
-        () => BookRemoteDataSourceImpl(dio: getIt<Dio>()),
+    () => BookRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Book CRUD
   getIt.registerLazySingleton<BookCrudRemoteDataSource>(
-        () => BookCrudRemoteDataSourceImpl(dio: getIt<Dio>()),
+    () => BookCrudRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // User
   getIt.registerLazySingleton<UserRemoteResources>(
-        () => UserRemoteResourcesImpl(dio: getIt<Dio>()),
+    () => UserRemoteResourcesImpl(dio: getIt<Dio>()),
   );
 
   // Search Location
   getIt.registerLazySingleton<SearchLocationRemoteResources>(
-        () => SearchLocationRemoteResourcesImpl(dio: getIt<Dio>()),
+    () => SearchLocationRemoteResourcesImpl(dio: getIt<Dio>()),
   );
 
   // Category CRUD
   getIt.registerLazySingleton<CategoryRemoteDataSource>(
-        () => CategoryRemoteDataSourceImpl(dio: getIt<Dio>()),
+    () => CategoryRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Banner
   getIt.registerLazySingleton<BannerRemoteDataSource>(
-        () => BannerRemoteDataSourceImpl(dio: getIt<Dio>()),
+    () => BannerRemoteDataSourceImpl(dio: getIt<Dio>()),
   );
 
   // Questionaries
   getIt.registerLazySingleton<OnboardingRemoteDataSource>(
-        () => OnboardingRemoteDataSourceImpl(
+    () => OnboardingRemoteDataSourceImpl(
       dio: getIt<Dio>(),
       secureStorage: getIt<SecureStorageUtil>(),
     ),
@@ -188,7 +170,7 @@ void _registerDataSources() {
 
   // Question CRUD (Admin)
   getIt.registerLazySingleton<QuestionCrudDataSource.QuestionRemoteDataSource>(
-        () => QuestionCrudDataSource.QuestionRemoteDataSource(
+    () => QuestionCrudDataSource.QuestionRemoteDataSource(
       getIt<Dio>(),
       getIt<SecureStorageUtil>(),
     ),
@@ -201,52 +183,47 @@ void _registerDataSources() {
 void _registerRepositories() {
   // Auth
   getIt.registerLazySingleton<AuthRepository>(
-        () => AuthRepositoryImpl(getIt<AuthRemoteDataSource>()),
-  );
-
-  // Profile
-  getIt.registerLazySingleton<ProfileRepository>(
-        () => ProfileRepositoryImpl(getIt<ProfileRemoteDataSource>()),
+    () => AuthRepositoryImpl(getIt<AuthRemoteDataSource>()),
   );
 
   // Books
   getIt.registerLazySingleton<BookRepository>(
-        () => BookRepositoryImpl(getIt<BookRemoteDataSource>()),
+    () => BookRepositoryImpl(getIt<BookRemoteDataSource>()),
   );
 
   // Book CRUD
   getIt.registerLazySingleton<BookCrudRepository>(
-        () => BookCrudRepositoryImpl(getIt<BookCrudRemoteDataSource>()),
+    () => BookCrudRepositoryImpl(getIt<BookCrudRemoteDataSource>()),
   );
 
   // User
   getIt.registerLazySingleton<UserRepository>(
-        () => UserRepositoryImpl(getIt<UserRemoteResources>()),
+    () => UserRepositoryImpl(getIt<UserRemoteResources>()),
   );
 
   // Search Location
   getIt.registerLazySingleton<SearchLocationRepository>(
-        () => SearchLocationRepoImpl(getIt<SearchLocationRemoteResources>()),
+    () => SearchLocationRepoImpl(getIt<SearchLocationRemoteResources>()),
   );
 
   // Category CRUD
   getIt.registerLazySingleton<CategoryRepository>(
-        () => CategoryRepositoryImpl(getIt<CategoryRemoteDataSource>()),
+    () => CategoryRepositoryImpl(getIt<CategoryRemoteDataSource>()),
   );
 
   // Banner
   getIt.registerLazySingleton<BannerRepository>(
-        () => BannerRepoImpl(remoteDataSource: getIt<BannerRemoteDataSource>()),
+    () => BannerRepoImpl(remoteDataSource: getIt<BannerRemoteDataSource>()),
   );
 
   // Questionaries
   getIt.registerLazySingleton<OnboardingRepository>(
-        () => OnboardingRepositoryImpl(getIt<OnboardingRemoteDataSource>()),
+    () => OnboardingRepositoryImpl(getIt<OnboardingRemoteDataSource>()),
   );
 
   // Question CRUD (Admin)
   getIt.registerLazySingleton<QuestionCrudDomain.QuestionRepository>(
-        () => QuestionCrudRepo.QuestionRepositoryImpl(
+    () => QuestionCrudRepo.QuestionRepositoryImpl(
       getIt<QuestionCrudDataSource.QuestionRemoteDataSource>(),
     ),
   );
@@ -265,11 +242,6 @@ void _registerUseCases() {
   getIt.registerLazySingleton(() => VerifyResetOtpUseCase(getIt<AuthRepository>()));
   getIt.registerLazySingleton(() => ChangePasswordUseCase(getIt<AuthRepository>()));
 
-  // Profile — added GetProfileUseCase and UpdateAvatarUseCase
-  getIt.registerLazySingleton(() => GetProfileUseCase(getIt<ProfileRepository>()));   // ← NEW
-  getIt.registerLazySingleton(() => UpdateAvatarUseCase(getIt<ProfileRepository>())); // ← NEW
-  getIt.registerLazySingleton(() => UpdateProfileUseCase(getIt<ProfileRepository>()));
-
   // Books
   getIt.registerLazySingleton(() => GetBooks(getIt<BookRepository>()));
 
@@ -286,16 +258,14 @@ void _registerUseCases() {
 
   // Search Location
   getIt.registerLazySingleton(
-          () => SearchLocationUsecase(getIt<SearchLocationRepository>()));
+    () => SearchLocationUsecase(getIt<SearchLocationRepository>()),
+  );
 
   // Category CRUD
   getIt.registerLazySingleton(() => AddCategoryUsecase(getIt<CategoryRepository>()));
-  getIt.registerLazySingleton(
-          () => DeleteCategoryUsecase(getIt<CategoryRepository>()));
-  getIt.registerLazySingleton(
-          () => GetCategoriesUsecase(getIt<CategoryRepository>()));
-  getIt.registerLazySingleton(
-          () => UpdateCategoryUsecase(getIt<CategoryRepository>()));
+  getIt.registerLazySingleton(() => DeleteCategoryUsecase(getIt<CategoryRepository>()));
+  getIt.registerLazySingleton(() => GetCategoriesUsecase(getIt<CategoryRepository>()));
+  getIt.registerLazySingleton(() => UpdateCategoryUsecase(getIt<CategoryRepository>()));
 
   // Banner
   getIt.registerLazySingleton(() => GetBannerUsecase(getIt<BannerRepository>()));
@@ -304,16 +274,11 @@ void _registerUseCases() {
   getIt.registerLazySingleton(() => DeleteBannerUsecase(getIt<BannerRepository>()));
 
   // Questionaries
-  getIt.registerLazySingleton(
-          () => GetQuestionsUseCase(getIt<OnboardingRepository>()));
-  getIt.registerLazySingleton(
-          () => SetPreferencesUseCase(getIt<OnboardingRepository>()));
-  getIt.registerLazySingleton(
-          () => UpdatePreferencesUseCase(getIt<OnboardingRepository>()));
-  getIt.registerLazySingleton(
-          () => DeletePreferencesUseCase(getIt<OnboardingRepository>()));
-  getIt.registerLazySingleton(
-          () => SetOnboardingStatusUseCase(getIt<OnboardingRepository>()));
+  getIt.registerLazySingleton(() => GetQuestionsUseCase(getIt<OnboardingRepository>()));
+  getIt.registerLazySingleton(() => SetPreferencesUseCase(getIt<OnboardingRepository>()));
+  getIt.registerLazySingleton(() => UpdatePreferencesUseCase(getIt<OnboardingRepository>()));
+  getIt.registerLazySingleton(() => DeletePreferencesUseCase(getIt<OnboardingRepository>()));
+  getIt.registerLazySingleton(() => SetOnboardingStatusUseCase(getIt<OnboardingRepository>()));
 
   // Question CRUD (Admin)
   getIt.registerLazySingleton(() => QuestionCrudUseCases.GetQuestions(
@@ -332,62 +297,54 @@ void _registerUseCases() {
 void _registerBlocs() {
   // Auth
   getIt.registerLazySingleton(() => SignInBloc(
-    getIt<SignIn>(),
-    getIt<SendOtpUseCase>(),
-    getIt<VerifyResetOtpUseCase>(),
-    getIt<ChangePasswordUseCase>(),
-  ));
+        getIt<SignIn>(),
+        getIt<SendOtpUseCase>(),
+        getIt<VerifyResetOtpUseCase>(),
+        getIt<ChangePasswordUseCase>(),
+      ));
   getIt.registerLazySingleton(() => GoogleSignInBloc(getIt<SignInWithGoogle>()));
   getIt.registerLazySingleton(() => SignUpBloc(
-    getIt<RegisterUserUseCase>(),
-    getIt<VerifyEmailUseCase>(),
-  ));
-
-  // Profile — fixed: added all 4 required constructor args
-  getIt.registerFactory(() => ProfileBloc(
-    getIt<SecureStorageUtil>(),
-    getIt<GetProfileUseCase>(),    // ← NEW
-    getIt<UpdateAvatarUseCase>(),  // ← NEW
-    getIt<UpdateProfileUseCase>(),
-  ));
+        getIt<RegisterUserUseCase>(),
+        getIt<VerifyEmailUseCase>(),
+      ));
 
   // Books
   getIt.registerLazySingleton(() => BookBloc(getIt<GetBooks>()));
 
   // Book CRUD
   getIt.registerLazySingleton(() => BookCrudBloc(
-    searchBooks: getIt<SearchBookUsecase>(),
-    addBookCrud: getIt<AddBookUsecase>(),
-    getBooksCrud: getIt<GetBooksUsecase>(),
-    getBookByIdCrud: getIt<GetBookByIdUsecase>(),
-    updateBookCrud: getIt<UpdateBookUsecase>(),
-    deleteBookCrud: getIt<DeleteBookusecase>(),
-  ));
+        searchBooks: getIt<SearchBookUsecase>(),
+        addBookCrud: getIt<AddBookUsecase>(),
+        getBooksCrud: getIt<GetBooksUsecase>(),
+        getBookByIdCrud: getIt<GetBookByIdUsecase>(),
+        updateBookCrud: getIt<UpdateBookUsecase>(),
+        deleteBookCrud: getIt<DeleteBookusecase>(),
+      ));
 
   // Category CRUD
   getIt.registerLazySingleton(() => CategoryBloc(
-    getCategories: getIt<GetCategoriesUsecase>(),
-    addCategory: getIt<AddCategoryUsecase>(),
-    updateCategory: getIt<UpdateCategoryUsecase>(),
-    deleteCategory: getIt<DeleteCategoryUsecase>(),
-  ));
+        getCategories: getIt<GetCategoriesUsecase>(),
+        addCategory: getIt<AddCategoryUsecase>(),
+        updateCategory: getIt<UpdateCategoryUsecase>(),
+        deleteCategory: getIt<DeleteCategoryUsecase>(),
+      ));
 
   // Banner
   getIt.registerLazySingleton(() => BannerBloc(
-    getBannerUsecase: getIt<GetBannerUsecase>(),
-    createBannerUsecase: getIt<CreateBannerUsecase>(),
-    updateBannerUsecase: getIt<UpdateBannerUsecase>(),
-    deleteBannerUsecase: getIt<DeleteBannerUsecase>(),
-  ));
+        getBannerUsecase: getIt<GetBannerUsecase>(),
+        createBannerUsecase: getIt<CreateBannerUsecase>(),
+        updateBannerUsecase: getIt<UpdateBannerUsecase>(),
+        deleteBannerUsecase: getIt<DeleteBannerUsecase>(),
+      ));
 
   // Questionaries
   getIt.registerFactory(() => OnboardingBloc(
-    getQuestionsUseCase: getIt<GetQuestionsUseCase>(),
-    setPreferencesUseCase: getIt<SetPreferencesUseCase>(),
-    updatePreferencesUseCase: getIt<UpdatePreferencesUseCase>(),
-    deletePreferencesUseCase: getIt<DeletePreferencesUseCase>(),
-    setOnboardingStatusUseCase: getIt<SetOnboardingStatusUseCase>(),
-  ));
+        getQuestionsUseCase: getIt<GetQuestionsUseCase>(),
+        setPreferencesUseCase: getIt<SetPreferencesUseCase>(),
+        updatePreferencesUseCase: getIt<UpdatePreferencesUseCase>(),
+        deletePreferencesUseCase: getIt<DeletePreferencesUseCase>(),
+        setOnboardingStatusUseCase: getIt<SetOnboardingStatusUseCase>(),
+      ));
 }
 
 // ========================================

--- a/lib/core/network/api_constants.dart
+++ b/lib/core/network/api_constants.dart
@@ -7,10 +7,14 @@ class ApiConstants {
   static const String verifyEmail = '$baseUrl/users/verify-email';
   static const String refreshToken = '$baseUrl/auth/refresh';
   static const String loginWithGoogle = '$baseUrl/googleauth/google-auth';
-
+  static const String resendResetOtp = '$baseUrl/users/resend-reset-otp';
+  static const String changePassword  = '$baseUrl/users/reset-password';
+  static const String verifyOtp = '$baseUrl/users/verify-reset-otp';
   // User endpoints
   static const String users = '$baseUrl/users';
-
+// Profile endpoints
+  static const String getProfile = '$baseUrl/users/profile';
+  static const String updateAvatar = '$baseUrl/users/update-avatar';
   // Book endpoints
   static const String books = '$baseUrl/books';
   static const String searchBooks = '$baseUrl/searchbook/search';

--- a/lib/core/utils/secure_storage_utils.dart
+++ b/lib/core/utils/secure_storage_utils.dart
@@ -94,7 +94,27 @@ class SecureStorageUtil {
   Future<void> saveOnboardingStatus(bool status) async {
     await write(key: 'onboardingStatus', value: status.toString());
   }
+// ─── Forgot Password Session ──────────────────────────────────────────────
 
+  Future<void> saveForgotPasswordSession({
+    required String email,
+    String? code,
+  }) async {
+    await write(key: 'fp_email', value: email);
+    if (code != null) await write(key: 'fp_code', value: code);
+  }
+
+  Future<Map<String, String?>> getForgotPasswordSession() async {
+    return {
+      'email': await read(key: 'fp_email'),
+      'code': await read(key: 'fp_code'),
+    };
+  }
+
+  Future<void> clearForgotPasswordSession() async {
+    await delete(key: 'fp_email');
+    await delete(key: 'fp_code');
+  }
   // ─── Generic ──────────────────────────────────────────────────────────────
 
   Future<void> write({required String key, required String value}) async {
@@ -112,4 +132,5 @@ class SecureStorageUtil {
   Future<void> clearAll() async {
     await _storage.deleteAll();
   }
+
 }

--- a/lib/features/auth/data/remotesource/auth_remote_data_source.dart
+++ b/lib/features/auth/data/remotesource/auth_remote_data_source.dart
@@ -6,11 +6,13 @@ import '../../../../core/utils/network_utils.dart';
 import '../models/app_user_model.dart';
 
 abstract class AuthRemoteDataSource {
-  Future<AppUserModel> signIn(
-      {required String email, required String password});
+  Future<AppUserModel> signIn({required String email, required String password});
   Future<AppUserModel> registerUser(Map<String, dynamic> data);
   Future<AppUserModel> verifyEmail(String email, String code);
   Future<AppUserModel> signInWithGoogle({required String token});
+  Future<void> sendOtp(String email);
+  Future<void> verifyResetOtp(String email, String otp);
+  Future<void> changePassword(String email, String code, String newPassword);
 }
 
 @Injectable(as: AuthRemoteDataSource)
@@ -30,7 +32,6 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       print('🌐 AuthRemoteDataSource: Email: $email');
     }
 
-    // Check network connectivity before making request
     final hasInternet = await NetworkUtils.hasInternetConnection();
     if (!hasInternet) {
       throw DioException(
@@ -41,40 +42,16 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
     }
 
     try {
-      final requestData = {
-        'email': email.trim().toLowerCase(),
-        'password': password,
-      };
-
-      if (kDebugMode) {
-        print('🌐 AuthRemoteDataSource: Request data: $requestData');
-      }
-
       final response = await _dio.post(
         ApiConstants.login,
-        data: requestData,
+        data: {
+          'email': email.trim().toLowerCase(),
+          'password': password,
+        },
       );
 
-      if (kDebugMode) {
-        print(
-            '🌐 AuthRemoteDataSource: Response status: ${response.statusCode}');
-        print('🌐 AuthRemoteDataSource: Response data: ${response.data}');
-      }
-
       if (response.statusCode == ApiConstants.success) {
-        final userModel = AppUserModel.fromJson(response.data);
-
-        if (kDebugMode) {
-          print('🌐 AuthRemoteDataSource: User model created successfully');
-          print('🌐 AuthRemoteDataSource: User name: ${userModel.name}');
-        }
-
-        return userModel;
-      }
-
-      if (kDebugMode) {
-        print(
-            '🌐 AuthRemoteDataSource: Login failed with status: ${response.statusCode}');
+        return AppUserModel.fromJson(response.data);
       }
 
       throw DioException(
@@ -83,23 +60,12 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
         message: 'Login failed with status: ${response.statusCode}',
       );
     } catch (e) {
-      if (kDebugMode) {
-        print('🌐 AuthRemoteDataSource: Exception occurred during sign in');
-        print('🌐 AuthRemoteDataSource: Exception type: ${e.runtimeType}');
-        print('🌐 AuthRemoteDataSource: Exception details: $e');
-      }
       rethrow;
     }
   }
 
   @override
   Future<AppUserModel> registerUser(Map<String, dynamic> data) async {
-    if (kDebugMode) {
-      print('🌐 AuthRemoteDataSource: Starting registration API call');
-      print('🌐 AuthRemoteDataSource: URL: ${ApiConstants.register}');
-    }
-
-    // Check network connectivity before making request
     final hasInternet = await NetworkUtils.hasInternetConnection();
     if (!hasInternet) {
       throw DioException(
@@ -110,28 +76,13 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
     }
 
     try {
-      // Clean and validate data
       final cleanData = {
         ...data,
         'email': data['email']?.toString().trim().toLowerCase(),
         'name': data['name']?.toString().trim(),
       };
 
-      if (kDebugMode) {
-        print('🌐 AuthRemoteDataSource: Clean data: $cleanData');
-      }
-
-      final response = await _dio.post(
-        ApiConstants.register,
-        data: cleanData,
-      );
-
-      if (kDebugMode) {
-        print(
-            '🌐 AuthRemoteDataSource: Registration response status: ${response.statusCode}');
-        print(
-            '🌐 AuthRemoteDataSource: Registration response data: ${response.data}');
-      }
+      final response = await _dio.post(ApiConstants.register, data: cleanData);
 
       if (response.statusCode == ApiConstants.success ||
           response.statusCode == ApiConstants.created) {
@@ -144,21 +95,12 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
         message: 'Registration failed',
       );
     } catch (e) {
-      if (kDebugMode) {
-        print('🌐 AuthRemoteDataSource: Registration exception: $e');
-      }
       rethrow;
     }
   }
 
   @override
   Future<AppUserModel> verifyEmail(String email, String code) async {
-    if (kDebugMode) {
-      print('🌐 AuthRemoteDataSource: Starting email verification API call');
-      print('🌐 AuthRemoteDataSource: URL: ${ApiConstants.verifyEmail}');
-    }
-
-    // Check network connectivity before making request
     final hasInternet = await NetworkUtils.hasInternetConnection();
     if (!hasInternet) {
       throw DioException(
@@ -177,11 +119,6 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
         },
       );
 
-      if (kDebugMode) {
-        print(
-            '🌐 AuthRemoteDataSource: Verification response status: ${response.statusCode}');
-      }
-
       if (response.statusCode == ApiConstants.success) {
         return AppUserModel.fromJson(response.data);
       }
@@ -192,9 +129,6 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
         message: 'Email verification failed',
       );
     } catch (e) {
-      if (kDebugMode) {
-        print('🌐 AuthRemoteDataSource: Email verification exception: $e');
-      }
       rethrow;
     }
   }
@@ -204,12 +138,8 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
     try {
       final response = await _dio.post(
         ApiConstants.loginWithGoogle,
-        data: {
-          'token': token,
-        },
+        data: {'token': token},
       );
-      print('Response status: ${response.statusCode}');
-      print('Response data: ${response.data}');
 
       if (response.statusCode == ApiConstants.success) {
         return AppUserModel.fromJson(response.data);
@@ -218,8 +148,116 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
       throw DioException(
         requestOptions: response.requestOptions,
         response: response,
-        message: 'Login failed',
+        message: 'Google login failed',
       );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> sendOtp(String email) async {
+    if (kDebugMode) print('🌐 AuthRemoteDataSource: Sending OTP to $email');
+
+    final hasInternet = await NetworkUtils.hasInternetConnection();
+    if (!hasInternet) {
+      throw DioException(
+        requestOptions: RequestOptions(path: ApiConstants.resendResetOtp),
+        type: DioExceptionType.connectionError,
+        message: 'No internet connection available',
+      );
+    }
+
+    try {
+      final response = await _dio.post(
+        ApiConstants.resendResetOtp,
+        data: {'email': email.trim().toLowerCase()},
+      );
+
+      if (kDebugMode) print('🌐 AuthRemoteDataSource: OTP sent ${response.statusCode}');
+
+      if (response.statusCode != ApiConstants.success &&
+          response.statusCode != ApiConstants.created) {
+        throw DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          message: 'Failed to send OTP',
+        );
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> verifyResetOtp(String email, String otp) async {
+    if (kDebugMode) print('🌐 AuthRemoteDataSource: Verifying OTP for $email');
+
+    final hasInternet = await NetworkUtils.hasInternetConnection();
+    if (!hasInternet) {
+      throw DioException(
+        requestOptions: RequestOptions(path: ApiConstants.verifyOtp),
+        type: DioExceptionType.connectionError,
+        message: 'No internet connection available',
+      );
+    }
+
+    try {
+      final response = await _dio.post(
+        ApiConstants.verifyOtp,
+        data: {
+          'email': email.trim().toLowerCase(),
+          'code': otp.trim(),
+        },
+      );
+
+      if (kDebugMode) print('🌐 AuthRemoteDataSource: OTP verified ${response.statusCode}');
+
+      if (response.statusCode != ApiConstants.success) {
+        throw DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          message: 'OTP verification failed',
+        );
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> changePassword(
+      String email, String code, String newPassword) async {
+    if (kDebugMode) print('🌐 AuthRemoteDataSource: Changing password for $email');
+
+    final hasInternet = await NetworkUtils.hasInternetConnection();
+    if (!hasInternet) {
+      throw DioException(
+        requestOptions: RequestOptions(path: ApiConstants.changePassword),
+        type: DioExceptionType.connectionError,
+        message: 'No internet connection available',
+      );
+    }
+
+    try {
+      final response = await _dio.post(
+        ApiConstants.changePassword,
+        data: {
+          'email': email.trim().toLowerCase(),
+          'code': code.trim(),
+          'newPassword': newPassword,
+        },
+      );
+
+      if (kDebugMode) print('🌐 AuthRemoteDataSource: Password changed ${response.statusCode}');
+
+      if (response.statusCode != ApiConstants.success) {
+        throw DioException(
+          requestOptions: response.requestOptions,
+          response: response,
+          message: 'Password change failed',
+        );
+      }
     } catch (e) {
       rethrow;
     }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -1,10 +1,8 @@
-// features/books/data/repositories/book_repository_impl.dart
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
-import 'package:read_buddy_app/features/auth/domain/entities/app_user.dart';
-
 import '../../domain/repositories/auth_repository.dart';
 import '../remotesource/auth_remote_data_source.dart';
+import 'package:read_buddy_app/features/auth/domain/entities/app_user.dart';
 
 @Injectable(as: AuthRepository)
 class AuthRepositoryImpl implements AuthRepository {
@@ -13,78 +11,10 @@ class AuthRepositoryImpl implements AuthRepository {
   AuthRepositoryImpl(this.remoteDataSource);
 
   @override
-  Future forgetPassword() {
-    // TODO: implement forgetPassword
-    throw UnimplementedError();
-  }
-
-  @override
-  Future<AppUser> registerUser(Map<String, dynamic> data) async {
-    if (kDebugMode) {
-      print('📦 AuthRepository: Starting user registration');
-    }
-
+  Future<AppUser> signIn({required String email, required String password}) async {
     try {
-      final result = await remoteDataSource.registerUser(data);
-
-      if (kDebugMode) {
-        print('📦 AuthRepository: Registration successful');
-      }
-
-      return result;
-    } catch (error) {
-      if (kDebugMode) {
-        print('📦 AuthRepository: Registration failed - $error');
-      }
-      rethrow;
-    }
-  }
-
-  @override
-  Future<AppUser> verifyEmail(String email, String code) async {
-    if (kDebugMode) {
-      print('📦 AuthRepository: Starting email verification');
-    }
-
-    try {
-      final result = await remoteDataSource.verifyEmail(email, code);
-
-      if (kDebugMode) {
-        print('📦 AuthRepository: Email verification successful');
-      }
-
-      return result;
-    } catch (error) {
-      if (kDebugMode) {
-        print('📦 AuthRepository: Email verification failed - $error');
-      }
-      rethrow;
-    }
-  }
-
-  @override
-  Future<AppUser> signIn(
-      {required String email, required String password}) async {
-    if (kDebugMode) {
-      print('📦 AuthRepository: Starting sign in');
-      print('📦 AuthRepository: Email: $email');
-    }
-
-    try {
-      final result =
-          await remoteDataSource.signIn(email: email, password: password);
-
-      if (kDebugMode) {
-        print('📦 AuthRepository: Sign in successful');
-        print('📦 AuthRepository: User: ${result.name}');
-      }
-
-      return result;
-    } catch (error) {
-      if (kDebugMode) {
-        print('📦 AuthRepository: Sign in failed');
-        print('📦 AuthRepository: Error: $error');
-      }
+      return await remoteDataSource.signIn(email: email, password: password);
+    } catch (e) {
       rethrow;
     }
   }
@@ -92,5 +22,53 @@ class AuthRepositoryImpl implements AuthRepository {
   @override
   Future<AppUser> signInUsingGoogle({required String token}) {
     return remoteDataSource.signInWithGoogle(token: token);
+  }
+
+  @override
+  Future<AppUser> registerUser(Map<String, dynamic> data) async {
+    try {
+      return await remoteDataSource.registerUser(data);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<AppUser> verifyEmail(String email, String code) async {
+    try {
+      return await remoteDataSource.verifyEmail(email, code);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> sendOtp(String email) async {
+    if (kDebugMode) print('📦 AuthRepository: Sending OTP to $email');
+    try {
+      await remoteDataSource.sendOtp(email);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> verifyResetOtp(String email, String otp) async {
+    if (kDebugMode) print('📦 AuthRepository: Verifying OTP for $email');
+    try {
+      await remoteDataSource.verifyResetOtp(email, otp);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> changePassword(String email, String code, String newPassword) async {
+    if (kDebugMode) print('📦 AuthRepository: Changing password for $email');
+    try {
+      await remoteDataSource.changePassword(email, code, newPassword);
+    } catch (e) {
+      rethrow;
+    }
   }
 }

--- a/lib/features/auth/domain/entities/app_user.dart
+++ b/lib/features/auth/domain/entities/app_user.dart
@@ -7,7 +7,7 @@ class AppUser {
   final bool isPrime;
   final int finesDue;
   final bool isEmailVerified;
-  final bool onboardingCompleted; // ← ADDED
+  final bool onboardingCompleted;
   final List<dynamic> badges;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -18,6 +18,7 @@ class AppUser {
   final String? phno;
   final String? gender;
   final List<dynamic>? wishlist;
+  final String? userAvatar; // ← ADDED
 
   AppUser({
     required this.id,
@@ -28,7 +29,7 @@ class AppUser {
     required this.isPrime,
     required this.finesDue,
     required this.isEmailVerified,
-    required this.onboardingCompleted, // ← ADDED
+    required this.onboardingCompleted,
     required this.badges,
     required this.createdAt,
     required this.updatedAt,
@@ -39,5 +40,61 @@ class AppUser {
     this.phno,
     this.gender,
     this.wishlist,
+    this.userAvatar, // ← ADDED
   });
+
+  factory AppUser.fromJson(Map<String, dynamic> json) {
+    // Support both flat response and nested { user: {...}, accessToken, refreshToken }
+    final Map<String, dynamic> u =
+    json['user'] != null ? json['user'] as Map<String, dynamic> : json;
+
+    return AppUser(
+      id: u['_id']?.toString() ?? u['id']?.toString() ?? '',
+      name: u['name']?.toString() ?? '',
+      email: u['email']?.toString() ?? '',
+      password: u['password']?.toString() ?? '',
+      role: u['role']?.toString() ?? 'user',
+      isPrime: u['isPrime'] as bool? ?? false,
+      finesDue: (u['finesDue'] as num?)?.toInt() ?? 0,
+      isEmailVerified: u['isEmailVerified'] as bool? ?? false,
+      onboardingCompleted: u['onboardingCompleted'] as bool? ?? false,
+      badges: u['badges'] as List<dynamic>? ?? [],
+      createdAt: u['createdAt'] != null
+          ? DateTime.tryParse(u['createdAt'].toString()) ?? DateTime.now()
+          : DateTime.now(),
+      updatedAt: u['updatedAt'] != null
+          ? DateTime.tryParse(u['updatedAt'].toString()) ?? DateTime.now()
+          : DateTime.now(),
+      version: (u['__v'] as num?)?.toInt() ?? 0,
+      // tokens can live at the root level or inside user object
+      accessToken: json['accessToken']?.toString() ??
+          u['accessToken']?.toString() ?? '',
+      refreshToken: json['refreshToken']?.toString() ??
+          u['refreshToken']?.toString() ?? '',
+      picture: u['picture']?.toString(),
+      phno: u['phno']?.toString(),
+      gender: u['gender']?.toString(),
+      wishlist: u['wishlist'] as List<dynamic>?,
+      userAvatar: u['userAvatar']?.toString(), // ← ADDED
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'name': name,
+    'email': email,
+    'role': role,
+    'isPrime': isPrime,
+    'finesDue': finesDue,
+    'isEmailVerified': isEmailVerified,
+    'onboardingCompleted': onboardingCompleted,
+    'badges': badges,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'picture': picture,
+    'phno': phno,
+    'gender': gender,
+    'wishlist': wishlist,
+    'userAvatar': userAvatar,
+  };
 }

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -5,5 +5,7 @@ abstract class AuthRepository {
   Future<AppUser> signInUsingGoogle({required String token});
   Future<AppUser> registerUser(Map<String, dynamic> data);
   Future<AppUser> verifyEmail(String email, String code);
-  Future<dynamic> forgetPassword();
+  Future<void> sendOtp(String email);
+  Future<void> verifyResetOtp(String email, String otp);
+  Future<void> changePassword(String email, String code, String newPassword);
 }

--- a/lib/features/auth/domain/usecases/change_password_usecase.dart
+++ b/lib/features/auth/domain/usecases/change_password_usecase.dart
@@ -1,0 +1,9 @@
+import '../repositories/auth_repository.dart';
+
+class ChangePasswordUseCase {
+  final AuthRepository _repository;
+  ChangePasswordUseCase(this._repository);
+
+  Future<void> call(String email, String code, String newPassword) =>
+      _repository.changePassword(email, code, newPassword);
+}

--- a/lib/features/auth/domain/usecases/send_otp_usecase.dart
+++ b/lib/features/auth/domain/usecases/send_otp_usecase.dart
@@ -1,0 +1,8 @@
+import '../repositories/auth_repository.dart';
+
+class SendOtpUseCase {
+  final AuthRepository _repository;
+  SendOtpUseCase(this._repository);
+
+  Future<void> call(String email) => _repository.sendOtp(email);
+}

--- a/lib/features/auth/domain/usecases/verify_reset_otp_usecase.dart
+++ b/lib/features/auth/domain/usecases/verify_reset_otp_usecase.dart
@@ -1,0 +1,9 @@
+import '../repositories/auth_repository.dart';
+
+class VerifyResetOtpUseCase {
+  final AuthRepository _repository;
+  VerifyResetOtpUseCase(this._repository);
+
+  Future<void> call(String email, String otp) =>
+      _repository.verifyResetOtp(email, otp);
+}

--- a/lib/features/auth/presentation/blocs/sign_in/sign_in_bloc.dart
+++ b/lib/features/auth/presentation/blocs/sign_in/sign_in_bloc.dart
@@ -5,6 +5,9 @@ import 'package:injectable/injectable.dart';
 import '../../../../../core/utils/error_handler.dart';
 import '../../../domain/entities/app_user.dart';
 import '../../../domain/usecases/sign_in.dart';
+import '../../../domain/usecases/send_otp_usecase.dart';
+import '../../../domain/usecases/verify_reset_otp_usecase.dart';
+import '../../../domain/usecases/change_password_usecase.dart';
 
 part 'sign_in_event.dart';
 part 'sign_in_state.dart';
@@ -12,58 +15,78 @@ part 'sign_in_state.dart';
 @injectable
 class SignInBloc extends Bloc<SignInEvent, SignInState> {
   final SignIn _signIn;
+  final SendOtpUseCase _sendOtp;
+  final VerifyResetOtpUseCase _verifyResetOtp;
+  final ChangePasswordUseCase _changePassword;
 
-  SignInBloc(this._signIn) : super(SignInInitial()) {
+  SignInBloc(
+      this._signIn,
+      this._sendOtp,
+      this._verifyResetOtp,
+      this._changePassword,
+      ) : super(SignInInitial()) {
     on<SignInRequest>(_onSignInRequest);
+    on<SendOtpRequested>(_onSendOtp);
+    on<VerifyOtpRequested>(_onVerifyOtp);
+    on<ChangePasswordRequested>(_onChangePassword);
   }
 
   Future<void> _onSignInRequest(
-    SignInRequest event,
-    Emitter<SignInState> emit,
-  ) async {
-    if (kDebugMode) {
-      print('🔐 SignInBloc: Starting sign in process');
-      print('🔐 SignInBloc: Email: ${event.email}');
-      print('🔐 SignInBloc: Password length: ${event.password.length}');
-    }
-
+      SignInRequest event,
+      Emitter<SignInState> emit,
+      ) async {
     emit(SignInLoading());
-
     try {
       final params = SignInParams(
         email: event.email.trim().toLowerCase(),
         password: event.password,
       );
-
-      if (kDebugMode) {
-        print('🔐 SignInBloc: Calling SignIn use case with params');
-        print('🔐 SignInBloc: Cleaned email: ${params.email}');
-      }
-
       final user = await _signIn(params);
-
-      if (kDebugMode) {
-        print('🔐 SignInBloc: Sign in successful');
-        print('🔐 SignInBloc: User ID: ${user.id}');
-        print('🔐 SignInBloc: User Name: ${user.name}');
-        print('🔐 SignInBloc: User Email: ${user.email}');
-      }
-
       emit(SignInSuccess(user));
     } catch (error) {
-      if (kDebugMode) {
-        print('🔐 SignInBloc: Sign in failed');
-        print('🔐 SignInBloc: Error type: ${error.runtimeType}');
-        print('🔐 SignInBloc: Error details: $error');
-      }
+      emit(SignInFailure(ErrorHandler.getErrorMessage(error)));
+    }
+  }
 
-      final errorMessage = ErrorHandler.getErrorMessage(error);
+  Future<void> _onSendOtp(
+      SendOtpRequested event,
+      Emitter<SignInState> emit,
+      ) async {
+    if (kDebugMode) print('🔐 SignInBloc: Sending OTP to ${event.email}');
+    emit(SignInLoading());
+    try {
+      await _sendOtp(event.email);
+      emit(OtpSentSuccess(event.email));
+    } catch (error) {
+      emit(SignInFailure(ErrorHandler.getErrorMessage(error)));
+    }
+  }
 
-      if (kDebugMode) {
-        print('🔐 SignInBloc: Processed error message: $errorMessage');
-      }
+  Future<void> _onVerifyOtp(
+      VerifyOtpRequested event,
+      Emitter<SignInState> emit,
+      ) async {
+    if (kDebugMode) print('🔐 SignInBloc: Verifying OTP for ${event.email}');
+    emit(SignInLoading());
+    try {
+      await _verifyResetOtp(event.email, event.otp);
+      emit(OtpVerifiedSuccess());
+    } catch (error) {
+      emit(SignInFailure(ErrorHandler.getErrorMessage(error)));
+    }
+  }
 
-      emit(SignInFailure(errorMessage));
+  Future<void> _onChangePassword(
+      ChangePasswordRequested event,
+      Emitter<SignInState> emit,
+      ) async {
+    if (kDebugMode) print('🔐 SignInBloc: Changing password for ${event.email}');
+    emit(SignInLoading());
+    try {
+      await _changePassword(event.email, event.code, event.newPassword);
+      emit(PasswordChangedSuccess());
+    } catch (error) {
+      emit(SignInFailure(ErrorHandler.getErrorMessage(error)));
     }
   }
 }

--- a/lib/features/auth/presentation/blocs/sign_in/sign_in_event.dart
+++ b/lib/features/auth/presentation/blocs/sign_in/sign_in_event.dart
@@ -13,3 +13,37 @@ final class SignInRequest extends SignInEvent {
   @override
   List<Object?> get props => [email, password];
 }
+
+final class SendOtpRequested extends SignInEvent {
+  final String email;
+
+  const SendOtpRequested(this.email);
+
+  @override
+  List<Object?> get props => [email];
+}
+
+final class VerifyOtpRequested extends SignInEvent {
+  final String email;
+  final String otp;
+
+  const VerifyOtpRequested({required this.email, required this.otp});
+
+  @override
+  List<Object?> get props => [email, otp];
+}
+
+final class ChangePasswordRequested extends SignInEvent {
+  final String email;
+  final String code;
+  final String newPassword;
+
+  const ChangePasswordRequested({
+    required this.email,
+    required this.code,
+    required this.newPassword,
+  });
+
+  @override
+  List<Object?> get props => [email, code, newPassword];
+}

--- a/lib/features/auth/presentation/blocs/sign_in/sign_in_state.dart
+++ b/lib/features/auth/presentation/blocs/sign_in/sign_in_state.dart
@@ -31,3 +31,22 @@ final class SignInFailure extends SignInState {
   @override
   List<Object> get props => [errorMessage];
 }
+
+final class OtpSentSuccess extends SignInState {
+  final String email;
+
+  const OtpSentSuccess(this.email);
+
+  @override
+  List<Object> get props => [email];
+}
+
+final class OtpVerifiedSuccess extends SignInState {
+  @override
+  List<Object> get props => [];
+}
+
+final class PasswordChangedSuccess extends SignInState {
+  @override
+  List<Object> get props => [];
+}

--- a/lib/features/auth/presentation/widgets/forget_password_page.dart
+++ b/lib/features/auth/presentation/widgets/forget_password_page.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/di/injection.dart';
+import '../../../../core/utils/secure_storage_utils.dart';
+import '../blocs/sign_in/sign_in_bloc.dart';
+import 'custom_button_widget.dart';
+
+class ForgotPasswordScreen extends StatefulWidget {
+  const ForgotPasswordScreen({super.key});
+
+  @override
+  State<ForgotPasswordScreen> createState() => _ForgotPasswordScreenState();
+}
+
+class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
+  late TextEditingController _emailController;
+
+  @override
+  void initState() {
+    super.initState();
+    _emailController = TextEditingController();
+    _restoreSession();
+  }
+
+  Future<void> _restoreSession() async {
+    final storage = getIt<SecureStorageUtil>();
+    final session = await storage.getForgotPasswordSession();
+    final savedEmail = session['email'];
+    if (savedEmail != null && savedEmail.isNotEmpty) {
+      _emailController.text = savedEmail;
+    }
+  }
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SignInBloc, SignInState>(
+      listener: (context, state) {
+        if (state is OtpSentSuccess) {
+          Navigator.pushNamed(context, '/verify-otp', arguments: state.email);
+        } else if (state is SignInFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.errorMessage),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 20),
+                const Text(
+                  'Forgot Password',
+                  style: TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF1E3A5F),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  'Select Email contact details should we\nuse to reset your password',
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Color(0xFF666666),
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 40),
+                const Text(
+                  'Email',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF1E3A5F),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: const Color(0xFFE0E0E0)),
+                  ),
+                  child: TextFormField(
+                    controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                    style: const TextStyle(
+                        fontSize: 16, color: Color(0xFF1E3A5F)),
+                    decoration: const InputDecoration(
+                      prefixIcon: Icon(Icons.email_outlined,
+                          color: Color(0xFF666666), size: 22),
+                      hintText: 'Enter your email',
+                      hintStyle:
+                      TextStyle(color: Color(0xFF999999), fontSize: 16),
+                      border: InputBorder.none,
+                      contentPadding:
+                      EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 40),
+                BlocBuilder<SignInBloc, SignInState>(
+                  builder: (context, state) {
+                    if (state is SignInLoading) {
+                      return const Center(
+                          child: CircularProgressIndicator(
+                              color: Color(0xFF00C853)));
+                    }
+                    return CustomButton(
+                      text: 'Continue',
+                      onPressed: () {
+                        final email = _emailController.text.trim();
+                        final emailRegex =
+                        RegExp(r'^[\w\.\+\-]+@[\w\-]+\.[a-zA-Z]{2,}$');
+                        if (email.isEmpty || !emailRegex.hasMatch(email)) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content:
+                              Text('Please enter a valid email address'),
+                              backgroundColor: Colors.red,
+                            ),
+                          );
+                          return;
+                        }
+                        context
+                            .read<SignInBloc>()
+                            .add(SendOtpRequested(email));
+                      },
+                    );
+                  },
+                ),
+                const Spacer(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/new_password_screen.dart
+++ b/lib/features/auth/presentation/widgets/new_password_screen.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/di/injection.dart';
+import '../../../../core/utils/secure_storage_utils.dart';
+import '../blocs/sign_in/sign_in_bloc.dart';
+import 'custom_button_widget.dart';
+
+class ResetPasswordScreen extends StatefulWidget {
+  const ResetPasswordScreen({super.key});
+
+  @override
+  State<ResetPasswordScreen> createState() => _ResetPasswordScreenState();
+}
+
+class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirm = true;
+
+  String? _email;
+  String? _otp;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSession();
+  }
+
+  Future<void> _loadSession() async {
+    final session = await getIt<SecureStorageUtil>().getForgotPasswordSession();
+    setState(() {
+      _email = session['email'];
+      _otp = session['code'];
+    });
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    final password = _passwordController.text;
+    final confirm = _confirmController.text;
+
+    if (_email == null || _otp == null) {
+      _showError('Session expired. Please restart the flow.');
+      return;
+    }
+    if (password.isEmpty || password.length < 6) {
+      _showError('Password must be at least 6 characters');
+      return;
+    }
+    if (password != confirm) {
+      _showError('Passwords do not match');
+      return;
+    }
+
+    context.read<SignInBloc>().add(ChangePasswordRequested(
+      email: _email!,
+      code: _otp!,
+      newPassword: password,
+    ));
+  }
+
+  void _showError(String msg) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(msg), backgroundColor: Colors.red),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SignInBloc, SignInState>(
+      listener: (context, state) async {
+        if (state is PasswordChangedSuccess) {
+          await getIt<SecureStorageUtil>().clearForgotPasswordSession();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Password changed successfully!'),
+              backgroundColor: Color(0xFF00C853),
+            ),
+          );
+          Navigator.of(context).popUntil((route) => route.isFirst);
+        } else if (state is SignInFailure) {
+          _showError(state.errorMessage);
+        }
+      },
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24.0),
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 12),
+                const Text(
+                  'New Password',
+                  style: TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF1E3A5F),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  'Set a strong new password for your account.',
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: Color(0xFF666666),
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 40),
+                const Text(
+                  'New Password',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF1E3A5F),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _passwordField(
+                  controller: _passwordController,
+                  hint: 'Enter new password',
+                  obscure: _obscurePassword,
+                  onToggle: () =>
+                      setState(() => _obscurePassword = !_obscurePassword),
+                ),
+                const SizedBox(height: 20),
+                const Text(
+                  'Confirm Password',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                    color: Color(0xFF1E3A5F),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                _passwordField(
+                  controller: _confirmController,
+                  hint: 'Confirm new password',
+                  obscure: _obscureConfirm,
+                  onToggle: () =>
+                      setState(() => _obscureConfirm = !_obscureConfirm),
+                ),
+                const SizedBox(height: 40),
+                BlocBuilder<SignInBloc, SignInState>(
+                  builder: (context, state) {
+                    if (state is SignInLoading) {
+                      return const Center(
+                        child: CircularProgressIndicator(
+                            color: Color(0xFF00C853)),
+                      );
+                    }
+                    return CustomButton(
+                      text: 'Reset Password',
+                      onPressed: _submit,
+                    );
+                  },
+                ),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _passwordField({
+    required TextEditingController controller,
+    required String hint,
+    required bool obscure,
+    required VoidCallback onToggle,
+  }) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: const Color(0xFFE0E0E0)),
+      ),
+      child: TextFormField(
+        controller: controller,
+        obscureText: obscure,
+        style: const TextStyle(fontSize: 15, color: Color(0xFF1E3A5F)),
+        decoration: InputDecoration(
+          prefixIcon: const Icon(Icons.lock_outline,
+              color: Color(0xFF666666), size: 20),
+          suffixIcon: IconButton(
+            icon: Icon(
+              obscure
+                  ? Icons.visibility_off_outlined
+                  : Icons.visibility_outlined,
+              color: const Color(0xFF666666),
+              size: 20,
+            ),
+            onPressed: onToggle,
+          ),
+          hintText: hint,
+          hintStyle:
+          const TextStyle(color: Color(0xFF999999), fontSize: 15),
+          border: InputBorder.none,
+          contentPadding:
+          const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/verification_otp_screen.dart
+++ b/lib/features/auth/presentation/widgets/verification_otp_screen.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/di/injection.dart';
+import '../../../../core/utils/secure_storage_utils.dart';
+import '../blocs/sign_in/sign_in_bloc.dart';
+import 'custom_button_widget.dart';
+
+class VerifyOtpScreen extends StatefulWidget {
+  final String email;
+  const VerifyOtpScreen({super.key, required this.email});
+
+  @override
+  State<VerifyOtpScreen> createState() => _VerifyOtpScreenState();
+}
+
+class _VerifyOtpScreenState extends State<VerifyOtpScreen>
+    with WidgetsBindingObserver {
+  static const int _otpLength = 6;
+
+  final List<TextEditingController> _controllers =
+  List.generate(_otpLength, (_) => TextEditingController());
+  final List<FocusNode> _focusNodes =
+  List.generate(_otpLength, (_) => FocusNode());
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) _tryAutoFill();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    for (final c in _controllers) c.dispose();
+    for (final f in _focusNodes) f.dispose();
+    super.dispose();
+  }
+
+  Future<void> _tryAutoFill() async {
+    final data = await Clipboard.getData(Clipboard.kTextPlain);
+    final digits = (data?.text ?? '').replaceAll(RegExp(r'\D'), '');
+    if (digits.length >= _otpLength) {
+      for (int i = 0; i < _otpLength; i++) {
+        _controllers[i].text = digits[i];
+      }
+      _focusNodes[_otpLength - 1].requestFocus();
+      setState(() {});
+    }
+  }
+
+  String get _otp => _controllers.map((c) => c.text).join();
+
+  void _onDigitChanged(int index, String value) {
+    if (value.isNotEmpty && index < _otpLength - 1) {
+      _focusNodes[index + 1].requestFocus();
+    } else if (value.isEmpty && index > 0) {
+      _focusNodes[index - 1].requestFocus();
+    }
+  }
+
+  void _submit() {
+    if (_otp.length < _otpLength) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Please enter the 6-digit code'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      return;
+    }
+    context.read<SignInBloc>().add(
+      VerifyOtpRequested(email: widget.email, otp: _otp),
+    );
+  }
+
+  void _clearOtp() {
+    for (final c in _controllers) c.clear();
+    _focusNodes[0].requestFocus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<SignInBloc, SignInState>(
+      listener: (context, state) async {
+        if (state is OtpVerifiedSuccess) {
+          await getIt<SecureStorageUtil>().saveForgotPasswordSession(
+            email: widget.email,
+            code: _otp,
+          );
+          Navigator.pushNamed(context, '/reset-password');
+        } else if (state is OtpSentSuccess) {
+          _clearOtp();
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('OTP resent successfully'),
+              backgroundColor: Color(0xFF00C853),
+            ),
+          );
+          Future.delayed(const Duration(milliseconds: 500), _tryAutoFill);
+        } else if (state is SignInFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.errorMessage),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      },
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        appBar: AppBar(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),
+            onPressed: () => Navigator.pop(context),
+          ),
+        ),
+        body: SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 12),
+                const Text(
+                  'Verify OTP',
+                  style: TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    color: Color(0xFF1E3A5F),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Enter the 6-digit code sent to\n${widget.email}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    color: Color(0xFF666666),
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 40),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: List.generate(_otpLength, (index) {
+                    return SizedBox(
+                      width: 46,
+                      height: 56,
+                      child: TextFormField(
+                        controller: _controllers[index],
+                        focusNode: _focusNodes[index],
+                        textAlign: TextAlign.center,
+                        keyboardType: TextInputType.number,
+                        inputFormatters: [
+                          FilteringTextInputFormatter.digitsOnly,
+                          LengthLimitingTextInputFormatter(1),
+                        ],
+                        style: const TextStyle(
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                          color: Color(0xFF1E3A5F),
+                        ),
+                        decoration: InputDecoration(
+                          counterText: '',
+                          filled: true,
+                          fillColor: const Color(0xFFF5F5F5),
+                          contentPadding: EdgeInsets.zero,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                            borderSide: BorderSide.none,
+                          ),
+                          focusedBorder: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(10),
+                            borderSide: const BorderSide(
+                                color: Color(0xFF00C853), width: 2),
+                          ),
+                        ),
+                        onTap: () {
+                          if (index == 0) _tryAutoFill();
+                        },
+                        onChanged: (value) => _onDigitChanged(index, value),
+                      ),
+                    );
+                  }),
+                ),
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: GestureDetector(
+                    onTap: () => context
+                        .read<SignInBloc>()
+                        .add(SendOtpRequested(widget.email)),
+                    child: const Text(
+                      'Resend code',
+                      style: TextStyle(
+                        color: Color(0xFF00C853),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+                const Spacer(),
+                BlocBuilder<SignInBloc, SignInState>(
+                  builder: (context, state) {
+                    if (state is SignInLoading) {
+                      return const Center(
+                        child: CircularProgressIndicator(
+                            color: Color(0xFF00C853)),
+                      );
+                    }
+                    return CustomButton(
+                      text: 'Verify',
+                      onPressed: _submit,
+                    );
+                  },
+                ),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:read_buddy_app/features/auth/presentation/pages/sign_in_page.dart';
 import 'package:read_buddy_app/features/auth/presentation/pages/sing_up_page.dart';
+import 'package:read_buddy_app/features/auth/presentation/widgets/forget_password_page.dart';
+import 'package:read_buddy_app/features/auth/presentation/widgets/new_password_screen.dart';
+import 'package:read_buddy_app/features/auth/presentation/widgets/verification_otp_screen.dart';
 import 'package:read_buddy_app/features/banner/presentation/pages/banner_list.dart';
 import 'package:read_buddy_app/features/bookcrud/presentation/pages/books_list_page.dart';
 import 'package:read_buddy_app/features/category_crud/presentation/pages/category_list_page.dart';
@@ -12,6 +15,7 @@ import '../features/auth/presentation/widgets/email_verification_widget.dart';
 import '../features/books/presentation/pages/book_page.dart';
 import '../features/dashboard/presentation/screens/admin_dashboard_screen.dart';
 import '../features/onboarding/onboarding_screens.dart';
+import '../features/profile/presentation/pages/screen/profile_screen.dart';
 import '../features/splash/splash_screen.dart';
 
 class AppRouter {
@@ -27,6 +31,15 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const SignInScreen());
       case '/signup':
         return MaterialPageRoute(builder: (_) => const SignUpScreen());
+      case '/forgot-password':
+        return MaterialPageRoute(builder: (_) => const ForgotPasswordScreen());
+      case '/verify-otp':
+        final email = settings.arguments as String? ?? '';
+        return MaterialPageRoute(
+          builder: (_) => VerifyOtpScreen(email: email),
+        );
+        case '/reset-password':
+        return MaterialPageRoute(builder: (_) => const ResetPasswordScreen());
       case '/admin':
         return MaterialPageRoute(builder: (_) => const AdminDashboardScreen());
       case '/category':
@@ -39,6 +52,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const DonationPage());
       case '/home':
         return MaterialPageRoute(builder: (_) => const HomeScreen());
+      case '/profile':
+        return MaterialPageRoute(builder: (_) => const ProfileScreen());
       case '/onboarding-questionnaire':
         return MaterialPageRoute(
             builder: (_) => const OnboardingQuestionnaire());

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -15,7 +15,6 @@ import '../features/auth/presentation/widgets/email_verification_widget.dart';
 import '../features/books/presentation/pages/book_page.dart';
 import '../features/dashboard/presentation/screens/admin_dashboard_screen.dart';
 import '../features/onboarding/onboarding_screens.dart';
-import '../features/profile/presentation/pages/screen/profile_screen.dart';
 import '../features/splash/splash_screen.dart';
 
 class AppRouter {
@@ -38,7 +37,7 @@ class AppRouter {
         return MaterialPageRoute(
           builder: (_) => VerifyOtpScreen(email: email),
         );
-        case '/reset-password':
+      case '/reset-password':
         return MaterialPageRoute(builder: (_) => const ResetPasswordScreen());
       case '/admin':
         return MaterialPageRoute(builder: (_) => const AdminDashboardScreen());
@@ -52,18 +51,18 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => const DonationPage());
       case '/home':
         return MaterialPageRoute(builder: (_) => const HomeScreen());
-      case '/profile':
-        return MaterialPageRoute(builder: (_) => const ProfileScreen());
       case '/onboarding-questionnaire':
         return MaterialPageRoute(
-            builder: (_) => const OnboardingQuestionnaire());
+          builder: (_) => const OnboardingQuestionnaire(),
+        );
       case '/verification':
         return MaterialPageRoute(builder: (_) => EmailVerificationScreen());
       case '/banner':
         return MaterialPageRoute(builder: (_) => const BannersList());
       case '/onboarding-page':
         return MaterialPageRoute(
-            builder: (_) => const OnboardingQuestionnaire());
+          builder: (_) => const OnboardingQuestionnaire(),
+        );
       default:
         return MaterialPageRoute(
           builder: (_) => const Scaffold(


### PR DESCRIPTION
## Summary
Implemented the complete forgot password flow for Read Buddy App.

## Changes Made

### New Features
- Forgot password screen (email input)
- OTP verification screen
- New password / reset password screen

### Auth Flow
- Added `send_otp_usecase.dart` — sends OTP to user email
- Added `verify_reset_otp_usecase.dart` — verifies OTP before reset
- Added `change_password_usecase.dart` — handles password update

### Modified Files
- `auth_remote_data_source.dart` — new API calls for OTP & reset
- `auth_repository_impl.dart` — implemented forgot password methods
- `auth_repository.dart` — added repository contracts
- `app_user.dart` — updated user entity
- `sign_in_bloc/event/state` — updated bloc for forgot password states
- `api_constants.dart` — added new endpoints
- `secure_storage_utils.dart` — token/session handling updates
- `injection.dart` — registered new use cases
- `app_router.dart` — added routes for new screens

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change

## Testing
- [ ] Tested OTP send flow
- [ ] Tested OTP verification
- [ ] Tested password reset
![WhatsApp Image 2026-03-31 at 2 22 29 PM](https://github.com/user-attachments/assets/7df91e38-afb1-4240-8f90-bfd17a6e7431)
![WhatsApp Image 2026-03-31 at 2 22 30 PM](https://github.com/user-attachments/assets/a00c45b2-4517-473d-8d55-2fc4893d18f6)
![WhatsApp Image 2026-03-31 at 2 22 30 PM (1)](https://github.com/user-attachments/assets/385eebba-fedd-4c4d-9876-f1d83af61c21)
![WhatsApp Image 2026-03-31 at 2 22 31 PM](https://github.com/user-attachments/assets/d3c7ece6-6dab-47f7-9668-5f7350996f3d)
![WhatsApp Image 2026-03-31 at 2 22 31 PM (1)](https://github.com/user-attachments/assets/913dd3b3-3c5a-4341-95bc-90871229389c)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete forgot password flow with email OTP verification and password reset across new screens, API, and Bloc. Also removes the profile module from DI/router to unblock CI and extends `AppUser` mapping.

- **New Features**
  - Screens: `ForgotPasswordScreen`, `VerifyOtpScreen`, `ResetPasswordScreen`.
  - Bloc: `SendOtpRequested`, `VerifyOtpRequested`, `ChangePasswordRequested` + `OtpSentSuccess`, `OtpVerifiedSuccess`, `PasswordChangedSuccess`.
  - Use cases and repo/data source: `sendOtp`, `verifyResetOtp`, `changePassword`.
  - API: `resendResetOtp`, `verifyOtp`, `changePassword` in `ApiConstants`; routes `'/forgot-password'`, `'/verify-otp'`, `'/reset-password'`.
  - Session: store/retrieve email and code via `SecureStorageUtil`.

- **Refactors**
  - DI: register new use cases and inject into `SignInBloc`; remove profile module wiring from DI/router to fix CI.
  - Model: `AppUser` supports nested responses and adds `userAvatar`.

<sup>Written for commit d4d9aa83092eeca32eaf040c46af9e6f2aadde3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full password reset flow: request reset by email, verify OTP, and set a new password.
  * OTP verification screen with per-digit entry, automatic clipboard detection, and resend support.
  * Forgot-password session persistence that pre-fills email across reset steps.
  * Profile enhancements: avatar support and profile retrieval/update endpoints.
  * Sign-in flow: clearer error handling and success states for OTP and password-change operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->