### PR TITLE
fix: add Kotlin plugin and register missing DI use cases

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.android.application"
+    id "org.jetbrains.kotlin.android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
 }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -24,6 +24,7 @@ plugins {
 
      id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include ":app"

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -460,9 +460,9 @@ void _registerUseCases() {
   getIt.registerLazySingleton(
       () => SchedulePickupUsecase(getIt<BookRequestRepository>()));
   getIt.registerLazySingleton(
-      () => SetFulfillmentUsecase(getIt<BookRequestRepository>()));
+      () => ScheduleDeliveryUsecase(getIt<BookRequestRepository>()));
   getIt.registerLazySingleton(
-      () => ConfirmPaymentUsecase(getIt<BookRequestRepository>()));
+      () => UpdateRequestStatusUsecase(getIt<BookRequestRepository>()));
   getIt.registerLazySingleton(
       () => GetUpcomingPickupsUsecase(getIt<BookRequestRepository>()));
 

--- a/lib/features/home/presentation/widgets/MainTab.dart
+++ b/lib/features/home/presentation/widgets/MainTab.dart
@@ -45,7 +45,9 @@ class _MainTabView extends StatelessWidget {
         listenWhen: (prev, curr) => curr is HomeLoaded && prev is! HomeLoaded,
         listener: (context, state) {
           if (state is HomeLoaded && state.isPrime) {
-            context.read<BannerBloc>().add(const GetBannerListEvent(typeFilter: 'homepage'));
+            context
+                .read<BannerBloc>()
+                .add(const GetBannerListEvent(typeFilter: 'homepage'));
           }
         },
         builder: (context, state) {
@@ -59,8 +61,7 @@ class _MainTabView extends StatelessWidget {
                 Text(state.message, textAlign: TextAlign.center),
                 const SizedBox(height: 12),
                 ElevatedButton(
-                  onPressed: () =>
-                      context.read<HomeBloc>().add(LoadHomeData()),
+                  onPressed: () => context.read<HomeBloc>().add(LoadHomeData()),
                   child: const Text('Retry'),
                 ),
               ]),
@@ -76,7 +77,7 @@ class _MainTabView extends StatelessWidget {
                   children: [
                     _BannerSection(
                       trendingCover:
-                      state.trendingBooks.firstOrNull?.coverImageUrl,
+                          state.trendingBooks.firstOrNull?.coverImageUrl,
                       isPrime: state.isPrime,
                       onDonatePressed: onDonatePressed,
                     ),
@@ -221,9 +222,9 @@ class _BannerSection extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                   child: trendingCover?.isNotEmpty == true
                       ? Image.network(trendingCover!,
-                      width: 115,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => _coverPlaceholder())
+                          width: 115,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => _coverPlaceholder())
                       : _coverPlaceholder(),
                 ),
               ),
@@ -231,15 +232,14 @@ class _BannerSection extends StatelessWidget {
           ),
         ),
       ),
-    ),
-  );
-}
+    );
+  }
 
   Widget _coverPlaceholder() => Container(
-    width: 115,
-    color: Colors.white12,
-    child: const Icon(Icons.menu_book, color: Colors.white38, size: 40),
-  );
+        width: 115,
+        color: Colors.white12,
+        child: const Icon(Icons.menu_book, color: Colors.white38, size: 40),
+      );
 }
 
 // ─────────────────────────────────────────────
@@ -321,161 +321,6 @@ class _BannerCarouselState extends State<_BannerCarousel> {
                         left: 0,
                         right: 0,
                         child: Container(
-                          padding:
-                          const EdgeInsets.fromLTRB(16, 28, 16, 14),
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                Colors.transparent,
-                                Colors.black.withOpacity(0.7),
-                              ],
-                            ),
-                          ),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              Text(
-                                banner.title,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 15,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                              ),
-                              if (banner.description?.isNotEmpty == true) ...[
-                                const SizedBox(height: 2),
-                                Text(
-                                  banner.description!,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: TextStyle(
-                                    color: Colors.white.withOpacity(0.85),
-                                    fontSize: 11,
-                                  ),
-                                ),
-                              ],
-                            ],
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-        const SizedBox(height: 10),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: List.generate(_totalPages, (i) {
-            final isActive = i == _currentPage;
-            return AnimatedContainer(
-              duration: const Duration(milliseconds: 250),
-              margin: const EdgeInsets.symmetric(horizontal: 3),
-              height: 6,
-              width: isActive ? 20 : 6,
-              decoration: BoxDecoration(
-                color: isActive
-                    ? const Color(0xFF2CE07F)
-                    : const Color(0xFFD0D5DD),
-                borderRadius: BorderRadius.circular(3),
-              ),
-            );
-          }),
-        ),
-      ],
-    );
-  }
-}
-
-// ─────────────────────────────────────────────
-// Banner Carousel — auto-scrolling image banners
-// ─────────────────────────────────────────────
-
-class _BannerCarousel extends StatefulWidget {
-  final List<BannerEntity> banners;
-  const _BannerCarousel({required this.banners});
-
-  @override
-  State<_BannerCarousel> createState() => _BannerCarouselState();
-}
-
-class _BannerCarouselState extends State<_BannerCarousel> {
-  late final PageController _pageController;
-  int _currentPage = 0;
-  late final int _totalPages;
-
-  @override
-  void initState() {
-    super.initState();
-    _totalPages = widget.banners.length;
-    _pageController = PageController(viewportFraction: 0.92);
-    // Auto-scroll every 4 seconds
-    _startAutoScroll();
-  }
-
-  void _startAutoScroll() {
-    Future.delayed(const Duration(seconds: 4), () {
-      if (!mounted) return;
-      final next = (_currentPage + 1) % _totalPages;
-      _pageController.animateToPage(
-        next,
-        duration: const Duration(milliseconds: 400),
-        curve: Curves.easeInOut,
-      );
-      _startAutoScroll();
-    });
-  }
-
-  @override
-  void dispose() {
-    _pageController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        SizedBox(
-          height: 175,
-          child: PageView.builder(
-            controller: _pageController,
-            itemCount: _totalPages,
-            onPageChanged: (i) => setState(() => _currentPage = i),
-            itemBuilder: (context, index) {
-              final banner = widget.banners[index];
-              return Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(20),
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      // Banner image
-                      Image.network(
-                        banner.bannerImage,
-                        fit: BoxFit.cover,
-                        errorBuilder: (_, __, ___) => Container(
-                          color: const Color(0xFF03405B),
-                          child: const Center(
-                            child: Icon(Icons.image_not_supported,
-                                color: Colors.white38, size: 40),
-                          ),
-                        ),
-                      ),
-                      // Gradient overlay for text readability
-                      Positioned(
-                        bottom: 0,
-                        left: 0,
-                        right: 0,
-                        child: Container(
                           padding: const EdgeInsets.fromLTRB(16, 28, 16, 14),
                           decoration: BoxDecoration(
                             gradient: LinearGradient(
@@ -525,7 +370,6 @@ class _BannerCarouselState extends State<_BannerCarousel> {
           ),
         ),
         const SizedBox(height: 10),
-        // Dot indicators
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: List.generate(_totalPages, (i) {
@@ -618,13 +462,12 @@ class _BookSectionState extends State<_BookSection> {
           child: widget.books.isEmpty
               ? const Center(child: Text('No books available'))
               : ListView.builder(
-            controller: _scrollController,
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            itemCount: widget.books.length,
-            itemBuilder: (_, i) =>
-                _BookCard(book: widget.books[i]),
-          ),
+                  controller: _scrollController,
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  itemCount: widget.books.length,
+                  itemBuilder: (_, i) => _BookCard(book: widget.books[i]),
+                ),
         ),
       ],
     );
@@ -668,13 +511,13 @@ class _BookCard extends StatelessWidget {
               children: [
                 ClipRRect(
                   borderRadius:
-                  const BorderRadius.vertical(top: Radius.circular(14)),
+                      const BorderRadius.vertical(top: Radius.circular(14)),
                   child: book.coverImageUrl?.isNotEmpty == true
                       ? Image.network(book.coverImageUrl!,
-                      height: 170,
-                      width: 140,
-                      fit: BoxFit.cover,
-                      errorBuilder: (_, __, ___) => _imgPlaceholder())
+                          height: 170,
+                          width: 140,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => _imgPlaceholder())
                       : _imgPlaceholder(),
                 ),
                 Positioned(
@@ -713,14 +556,14 @@ class _BookCard extends StatelessWidget {
   }
 
   Widget _imgPlaceholder() => Container(
-    height: 170,
-    width: 140,
-    decoration: const BoxDecoration(
-      color: Color(0xFFE8EDF2),
-      borderRadius: BorderRadius.vertical(top: Radius.circular(14)),
-    ),
-    child: const Icon(Icons.book, size: 44, color: Color(0xFFB0BEC5)),
-  );
+        height: 170,
+        width: 140,
+        decoration: const BoxDecoration(
+          color: Color(0xFFE8EDF2),
+          borderRadius: BorderRadius.vertical(top: Radius.circular(14)),
+        ),
+        child: const Icon(Icons.book, size: 44, color: Color(0xFFB0BEC5)),
+      );
 }
 
 // ─────────────────────────────────────────────
@@ -802,15 +645,13 @@ class _MonthlyStatsCardState extends State<_MonthlyStatsCard> {
             if (snap.connectionState == ConnectionState.waiting) {
               return const SizedBox(
                   height: 100,
-                  child: Center(
-                      child:
-                      CircularProgressIndicator(strokeWidth: 2)));
+                  child:
+                      Center(child: CircularProgressIndicator(strokeWidth: 2)));
             }
             if (snap.hasError) {
               return const SizedBox(
                   height: 100,
-                  child:
-                  Center(child: Text('Could not load stats')));
+                  child: Center(child: Text('Could not load stats')));
             }
 
             final s = snap.data!;
@@ -864,9 +705,7 @@ class _StatItem extends StatelessWidget {
         const SizedBox(height: 8),
         Text('$value',
             style: const TextStyle(
-                fontSize: 22,
-                fontWeight: FontWeight.bold,
-                color: _primary)),
+                fontSize: 22, fontWeight: FontWeight.bold, color: _primary)),
         const SizedBox(height: 4),
         Text(label,
             style: const TextStyle(

--- a/lib/features/question_crud/presentation/pages/question_list_page.dart
+++ b/lib/features/question_crud/presentation/pages/question_list_page.dart
@@ -205,7 +205,8 @@ class _QuestionListPageState extends State<QuestionListPage> {
                                   const SizedBox(width: 8),
                                   Container(
                                     decoration: BoxDecoration(
-                                      color: Colors.green.withOpacity(0.1),
+                                      color:
+                                          Colors.green.withValues(alpha: 0.1),
                                       borderRadius: BorderRadius.circular(12),
                                     ),
                                     padding: const EdgeInsets.symmetric(
@@ -275,7 +276,8 @@ class _QuestionListPageState extends State<QuestionListPage> {
                                         width: 20,
                                         height: 20,
                                         decoration: BoxDecoration(
-                                          color: Colors.green.withOpacity(0.1),
+                                          color: Colors.green
+                                              .withValues(alpha: 0.1),
                                           borderRadius:
                                               BorderRadius.circular(10),
                                         ),

--- a/lib/features/rewards/presentation/widgets/challenges_section.dart
+++ b/lib/features/rewards/presentation/widgets/challenges_section.dart
@@ -5,10 +5,10 @@ class ChallengesSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return const Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
+        Text(
           'Current Challenges',
           style: TextStyle(
             fontFamily: 'Poppins',
@@ -17,15 +17,15 @@ class ChallengesSection extends StatelessWidget {
             color: Color(0xFF052E44),
           ),
         ),
-        const SizedBox(height: 10),
-        const _ChallengeCard(
+        SizedBox(height: 10),
+        _ChallengeCard(
           title: 'Read 2 Book in this Week',
           progress: '1/3',
           points: 100,
           backgroundColor: Color(0xFFEAEAEA),
         ),
-        const SizedBox(height: 8),
-        const _ChallengeCard(
+        SizedBox(height: 8),
+        _ChallengeCard(
           title: 'Write your Review',
           progress: '0/3',
           points: 100,

--- a/lib/features/rewards/presentation/widgets/my_rewards_card.dart
+++ b/lib/features/rewards/presentation/widgets/my_rewards_card.dart
@@ -20,11 +20,11 @@ class MyRewardsCard extends StatelessWidget {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Row(
+              const Row(
                 children: [
-                  const Icon(Icons.menu_book, color: Colors.white, size: 28),
-                  const SizedBox(width: 8),
-                  const Text(
+                  Icon(Icons.menu_book, color: Colors.white, size: 28),
+                  SizedBox(width: 8),
+                  Text(
                     'Book',
                     style: TextStyle(
                       fontFamily: 'Poppins',

--- a/lib/features/rewards/presentation/widgets/reading_streak_card.dart
+++ b/lib/features/rewards/presentation/widgets/reading_streak_card.dart
@@ -19,10 +19,10 @@ class ReadingStreakCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Header row
-          Row(
+          const Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              const Text(
+              Text(
                 'Reading Streak',
                 style: TextStyle(
                   fontFamily: 'Poppins',
@@ -31,7 +31,7 @@ class ReadingStreakCard extends StatelessWidget {
                   color: Color(0xFF000000),
                 ),
               ),
-              const Text(
+              Text(
                 '7 days',
                 style: TextStyle(
                   fontFamily: 'Poppins',


### PR DESCRIPTION
## Summary

- **Gradle build fix**: Added `org.jetbrains.kotlin.android` plugin to `settings.gradle` and `app/build.gradle` to resolve `kotlinOptions()` method not found error with AGP 8.11.1
- **Runtime DI fix**: Registered `ScheduleDeliveryUsecase` and `UpdateRequestStatusUsecase` in GetIt to fix `BookRequestBloc` creation failure

## What was tested
- Debug APK builds successfully after `flutter clean`
- `flutter analyze` passes with no errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android builds on AGP 8.11.1 and a runtime DI crash by adding the Kotlin plugin and registering missing use cases in `GetIt`. Also cleans up Home/Rewards UI and updates color API usage; `BookRequestBloc` now initializes correctly.

- **Bug Fixes**
  - Gradle: Add `org.jetbrains.kotlin.android` in `android/settings.gradle` and `android/app/build.gradle` to restore `kotlinOptions` with AGP 8.11.1.
  - DI: Register `ScheduleDeliveryUsecase` and `UpdateRequestStatusUsecase` in `GetIt` to satisfy `BookRequestBloc` dependencies.

<sup>Written for commit 3667dba287637cdf8c25d380725c134d229a834a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kunalgharate/read-buddy-app/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build infrastructure with Kotlin support improvements
* **Refactor**
  * Streamlined booking request management system for improved delivery scheduling and status tracking

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kunalgharate/read-buddy-app/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->