### PR TITLE
fix: dark theme applied to all modules + address field appending bug

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    id("dev.flutter.flutter-gradle-plugin")
+}
+
+android {
+    namespace = "in.thecodershub.read_buddy_app"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
+    defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId = "in.thecodershub.read_buddy_app"
+        // You can update the following values to match your application needs.
+        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
+    }
+
+    buildTypes {
+        release {
+            // TODO: Add your own signing config for the release build.
+            // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
+}
+
+flutter {
+    source = "../.."
+}

--- a/android/app/src/main/kotlin/in/thecodershub/read_buddy_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/in/thecodershub/read_buddy_app/MainActivity.kt
@@ -1,0 +1,5 @@
+package `in`.thecodershub.read_buddy_app
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,24 @@
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+val newBuildDir: Directory =
+    rootProject.layout.buildDirectory
+        .dir("../../build")
+        .get()
+rootProject.layout.buildDirectory.value(newBuildDir)
+
+subprojects {
+    val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
+    project.layout.buildDirectory.value(newSubprojectBuildDir)
+}
+subprojects {
+    project.evaluationDependsOn(":app")
+}
+
+tasks.register<Delete>("clean") {
+    delete(rootProject.layout.buildDirectory)
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,26 @@
+pluginManagement {
+    val flutterSdkPath =
+        run {
+            val properties = java.util.Properties()
+            file("local.properties").inputStream().use { properties.load(it) }
+            val flutterSdkPath = properties.getProperty("flutter.sdk")
+            require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
+            flutterSdkPath
+        }
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+}
+
+include(":app")

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -192,6 +192,16 @@ import 'package:read_buddy_app/features/address/presentation/bloc/address_bloc.d
 import 'package:read_buddy_app/features/librarian/data/datasources/librarian_remote_datasource.dart';
 import 'package:read_buddy_app/features/librarian/presentation/bloc/librarian_bloc.dart';
 
+// Reviews
+import 'package:read_buddy_app/features/reviews/data/datasources/review_remote_datasource.dart';
+import 'package:read_buddy_app/features/reviews/data/repositories/review_repository_impl.dart';
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/get_book_reviews.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/create_review.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/update_review.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/delete_review.dart';
+import 'package:read_buddy_app/features/reviews/presentation/bloc/review_bloc.dart';
+
 final getIt = GetIt.instance;
 
 Future<void> configureDependencies() async {
@@ -205,6 +215,7 @@ Future<void> configureDependencies() async {
   _registerLibraryFeature();
   _registerAddressFeature();
   _registerLibrarianFeature();
+  _registerReviewsFeature();
 }
 
 // ========================================
@@ -789,4 +800,33 @@ void _registerLibrarianFeature() {
 
   getIt
       .registerFactory(() => LibrarianBloc(getIt<LibrarianRemoteDataSource>()));
+}
+
+// ========================================
+// REVIEWS FEATURE
+// ========================================
+void _registerReviewsFeature() {
+  // DataSource
+  getIt.registerLazySingleton<ReviewRemoteDataSource>(
+    () => ReviewRemoteDataSourceImpl(dio: getIt<Dio>()),
+  );
+
+  // Repository
+  getIt.registerLazySingleton<ReviewRepository>(
+    () => ReviewRepositoryImpl(getIt<ReviewRemoteDataSource>()),
+  );
+
+  // UseCases
+  getIt.registerLazySingleton(() => GetBookReviews(getIt<ReviewRepository>()));
+  getIt.registerLazySingleton(() => CreateReview(getIt<ReviewRepository>()));
+  getIt.registerLazySingleton(() => UpdateReview(getIt<ReviewRepository>()));
+  getIt.registerLazySingleton(() => DeleteReview(getIt<ReviewRepository>()));
+
+  // BLoC
+  getIt.registerFactory(() => ReviewBloc(
+        getBookReviews: getIt<GetBookReviews>(),
+        createReview: getIt<CreateReview>(),
+        updateReview: getIt<UpdateReview>(),
+        deleteReview: getIt<DeleteReview>(),
+      ));
 }

--- a/lib/core/network/api_constants.dart
+++ b/lib/core/network/api_constants.dart
@@ -12,6 +12,10 @@ class ApiConstants {
   static String get resendResetOtp => '$baseUrl/users/resend-reset-otp';
   static String get changePassword => '$baseUrl/users/reset-password';
   static String get verifyOtp => '$baseUrl/users/verify-reset-otp';
+  static String get logout => '$baseUrl/users/logout';
+  static String get resendRegisterOtp => '$baseUrl/users/resend-register-otp';
+  static String get changePasswordAuth => '$baseUrl/users/change-password';
+  static String get uploadProfileImage => '$baseUrl/users/upload-profile-image';
 
   // User endpoints
   static String get users => '$baseUrl/users';
@@ -60,6 +64,11 @@ class ApiConstants {
   static String get libraryDetails => '$baseUrl/v1/libraries/details';
 
   static String get olaMap => '$baseUrl/ola/address?input';
+
+  // Reviews
+  static String get reviews => '$baseUrl/review';
+  static String reviewById(String id) => '$baseUrl/review/$id';
+  static String reviewsByBook(String bookId) => '$baseUrl/review/book/$bookId';
 
   // HTTP Status Codes
   static const int success = 200;
@@ -132,4 +141,29 @@ class ApiConstants {
       '$librarianDonations/$id/status';
   static String librarianDonationSchedulePickup(String id) =>
       '$librarianDonations/$id/schedule-pickup';
+
+  // Admin Dashboard
+  static String get adminDashboard => '$baseUrl/admindashboard/dashboard';
+  static String get dashboardCounts => '$baseUrl/dashboard/dashboard-counts';
+
+  // Return Requests
+  static String get returnRequests => '$baseUrl/users/return-requests';
+  static String returnRequestById(String id) =>
+      '$baseUrl/users/return-requests/$id';
+  static String returnRequestMethod(String id) =>
+      '$baseUrl/users/return-requests/$id/method';
+  static String returnRequestPayment(String id) =>
+      '$baseUrl/users/return-requests/$id/payment';
+  static String returnRequestDropConfirm(String id) =>
+      '$baseUrl/users/return-requests/$id/drop-confirm';
+  static String returnRequestReceive(String id) =>
+      '$baseUrl/users/return-requests/$id/receive';
+  static String returnRequestInspect(String id) =>
+      '$baseUrl/users/return-requests/$id/inspect';
+
+  // Shipments
+  static String get shipments => '$baseUrl/shipments';
+  static String shipmentById(String id) => '$baseUrl/shipments/$id';
+  static String shipmentByRequest(String requestId) =>
+      '$baseUrl/shipments/request/$requestId';
 }

--- a/lib/features/address/data/models/address_model.dart
+++ b/lib/features/address/data/models/address_model.dart
@@ -17,17 +17,29 @@ class AddressModel extends AddressEntity {
   });
 
   factory AddressModel.fromJson(Map<String, dynamic> json) {
+    // Parse individual fields first
+    String line1 = json['addressLine1']?.toString() ?? '';
+    String line2 = json['addressLine2']?.toString() ?? '';
+    String city = json['city']?.toString() ?? '';
+    String state = json['state']?.toString() ?? '';
+    String pincode = json['pincode']?.toString() ?? '';
+
+    // Fallback: if individual fields are empty but combined `address` exists,
+    // use it only for line1 (don't try to split since we can't reliably parse).
+    if (line1.isEmpty && json['address'] != null) {
+      line1 = json['address'].toString();
+    }
+
     return AddressModel(
       id: json['_id']?.toString() ?? '',
       label: json['label']?.toString() ?? 'Home',
       name: json['name']?.toString() ?? '',
       phone: json['phone']?.toString() ?? '',
-      addressLine1:
-          json['addressLine1']?.toString() ?? json['address']?.toString() ?? '',
-      addressLine2: json['addressLine2']?.toString() ?? '',
-      city: json['city']?.toString() ?? '',
-      state: json['state']?.toString() ?? '',
-      pincode: json['pincode']?.toString() ?? '',
+      addressLine1: line1,
+      addressLine2: line2,
+      city: city,
+      state: state,
+      pincode: pincode,
       latitude: (json['latitude'] ?? 0).toDouble(),
       longitude: (json['longitude'] ?? 0).toDouble(),
       isDefault: json['isDefault'] as bool? ?? false,
@@ -38,9 +50,6 @@ class AddressModel extends AddressEntity {
         'label': label,
         'name': name,
         'phone': phone,
-        'address': [addressLine1, addressLine2, city, state, pincode]
-            .where((s) => s.isNotEmpty)
-            .join(', '),
         'addressLine1': addressLine1,
         'addressLine2': addressLine2,
         'city': city,

--- a/lib/features/auth/presentation/pages/change_password_page.dart
+++ b/lib/features/auth/presentation/pages/change_password_page.dart
@@ -1,0 +1,253 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:read_buddy_app/core/di/injection.dart';
+import 'package:read_buddy_app/core/network/api_constants.dart';
+import 'package:read_buddy_app/core/theme/app_colors.dart';
+
+/// Allows authenticated users to change their password by providing
+/// their current password and a new password.
+class ChangePasswordPage extends StatefulWidget {
+  const ChangePasswordPage({super.key});
+
+  @override
+  State<ChangePasswordPage> createState() => _ChangePasswordPageState();
+}
+
+class _ChangePasswordPageState extends State<ChangePasswordPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _currentPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  bool _isLoading = false;
+  bool _obscureCurrent = true;
+  bool _obscureNew = true;
+  bool _obscureConfirm = true;
+
+  @override
+  void dispose() {
+    _currentPasswordController.dispose();
+    _newPasswordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    try {
+      await getIt<Dio>().post(
+        ApiConstants.changePasswordAuth,
+        data: {
+          'currentPassword': _currentPasswordController.text.trim(),
+          'newPassword': _newPasswordController.text.trim(),
+        },
+      );
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Password changed successfully'),
+          backgroundColor: AppColors.primary,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      Navigator.pop(context);
+    } on DioException catch (e) {
+      if (!mounted) return;
+
+      String errorMessage = 'Failed to change password';
+      if (e.response?.data is Map) {
+        errorMessage = (e.response?.data['message'] ??
+                e.response?.data['error'] ??
+                errorMessage)
+            .toString();
+      }
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(errorMessage),
+          backgroundColor: Colors.redAccent,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        surfaceTintColor: Colors.transparent,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text(
+          'Change Password',
+          style: TextStyle(
+            color: Color(0xFF052E44),
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Enter your current password and choose a new password.',
+                style: TextStyle(
+                  fontSize: 14,
+                  color: Color(0xFF888888),
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 28),
+
+              // Current Password
+              _buildPasswordField(
+                controller: _currentPasswordController,
+                label: 'Current Password',
+                obscure: _obscureCurrent,
+                onToggle: () =>
+                    setState(() => _obscureCurrent = !_obscureCurrent),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter your current password';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // New Password
+              _buildPasswordField(
+                controller: _newPasswordController,
+                label: 'New Password',
+                obscure: _obscureNew,
+                onToggle: () => setState(() => _obscureNew = !_obscureNew),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a new password';
+                  }
+                  if (value.trim().length < 6) {
+                    return 'Password must be at least 6 characters';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              // Confirm New Password
+              _buildPasswordField(
+                controller: _confirmPasswordController,
+                label: 'Confirm New Password',
+                obscure: _obscureConfirm,
+                onToggle: () =>
+                    setState(() => _obscureConfirm = !_obscureConfirm),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please confirm your new password';
+                  }
+                  if (value.trim() != _newPasswordController.text.trim()) {
+                    return 'Passwords do not match';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 36),
+
+              // Submit button
+              SizedBox(
+                width: double.infinity,
+                height: 52,
+                child: ElevatedButton(
+                  onPressed: _isLoading ? null : _submit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: Colors.white,
+                    elevation: 0,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: _isLoading
+                      ? const SizedBox(
+                          width: 24,
+                          height: 24,
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                            strokeWidth: 2.5,
+                          ),
+                        )
+                      : const Text(
+                          'Change Password',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPasswordField({
+    required TextEditingController controller,
+    required String label,
+    required bool obscure,
+    required VoidCallback onToggle,
+    required String? Function(String?) validator,
+  }) {
+    return TextFormField(
+      controller: controller,
+      obscureText: obscure,
+      validator: validator,
+      decoration: InputDecoration(
+        labelText: label,
+        labelStyle: const TextStyle(fontSize: 14, color: Color(0xFF888888)),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(color: Colors.grey.shade300),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: BorderSide(color: Colors.grey.shade300),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary, width: 1.5),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: Colors.redAccent),
+        ),
+        suffixIcon: IconButton(
+          icon: Icon(
+            obscure ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+            color: const Color(0xFF888888),
+          ),
+          onPressed: onToggle,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/pages/forget_password_page.dart
+++ b/lib/features/auth/presentation/pages/forget_password_page.dart
@@ -33,9 +33,9 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),

--- a/lib/features/auth/presentation/widgets/email_verification_widget.dart
+++ b/lib/features/auth/presentation/widgets/email_verification_widget.dart
@@ -134,7 +134,7 @@ class EmailVerificationScreen extends StatelessWidget {
 
         if (currentUser != null) {
           return Scaffold(
-            backgroundColor: Colors.white,
+      
             appBar: AppBar(
               backgroundColor: Colors.transparent,
               elevation: 0,

--- a/lib/features/auth/presentation/widgets/forget_password_page.dart
+++ b/lib/features/auth/presentation/widgets/forget_password_page.dart
@@ -53,9 +53,9 @@ class _ForgotPasswordScreenState extends State<ForgotPasswordScreen> {
         }
       },
       child: Scaffold(
-        backgroundColor: Colors.white,
+  
         appBar: AppBar(
-          backgroundColor: Colors.white,
+    
           elevation: 0,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),

--- a/lib/features/auth/presentation/widgets/new_password_screen.dart
+++ b/lib/features/auth/presentation/widgets/new_password_screen.dart
@@ -91,9 +91,9 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
         }
       },
       child: Scaffold(
-        backgroundColor: Colors.white,
+  
         appBar: AppBar(
-          backgroundColor: Colors.white,
+    
           elevation: 0,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),

--- a/lib/features/auth/presentation/widgets/verification_otp_screen.dart
+++ b/lib/features/auth/presentation/widgets/verification_otp_screen.dart
@@ -120,9 +120,9 @@ class _VerifyOtpScreenState extends State<VerifyOtpScreen>
         }
       },
       child: Scaffold(
-        backgroundColor: Colors.white,
+  
         appBar: AppBar(
-          backgroundColor: Colors.white,
+    
           elevation: 0,
           leading: IconButton(
             icon: const Icon(Icons.arrow_back, color: Color(0xFF1E3A5F)),

--- a/lib/features/banner/presentation/pages/banner_list.dart
+++ b/lib/features/banner/presentation/pages/banner_list.dart
@@ -21,9 +21,9 @@ class _BannersListState extends State<BannersList> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         title: const Text('Banners'),
         centerTitle: true,
       ),

--- a/lib/features/banner/presentation/pages/delete_banner.dart
+++ b/lib/features/banner/presentation/pages/delete_banner.dart
@@ -8,7 +8,7 @@ class DeleteBanner {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: Colors.white,
+  
         content: const Text(
           "Are you sure you want to permanently delete this banner from the ReadBuddy app?",
           style: TextStyle(fontSize: 15),

--- a/lib/features/book_request/presentation/pages/admin_book_requests_page.dart
+++ b/lib/features/book_request/presentation/pages/admin_book_requests_page.dart
@@ -72,9 +72,9 @@ class _AdminBookRequestsViewState extends State<_AdminBookRequestsView>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(
@@ -215,7 +215,7 @@ class _AdminBookRequestsViewState extends State<_AdminBookRequestsView>
     showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
-        backgroundColor: Colors.white,
+  
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         title: const Text(
           'Decline Request',
@@ -297,7 +297,7 @@ class _AdminBookRequestsViewState extends State<_AdminBookRequestsView>
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
-      backgroundColor: Colors.white,
+
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -377,7 +377,7 @@ class _RequestCard extends StatelessWidget {
       onTap: onTap,
       child: Container(
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: Theme.of(context).cardColor,
           borderRadius: BorderRadius.circular(10),
           border: Border.all(color: const Color(0xFFE0E0E0)),
         ),

--- a/lib/features/book_request/presentation/pages/admin_return_requests_page.dart
+++ b/lib/features/book_request/presentation/pages/admin_return_requests_page.dart
@@ -1,0 +1,381 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:read_buddy_app/core/di/injection.dart';
+import 'package:read_buddy_app/core/network/api_constants.dart';
+import 'package:read_buddy_app/core/theme/app_colors.dart';
+
+/// Admin page for managing book return requests.
+/// Fetches all requests with 'returning' status and allows marking
+/// them as received or completing inspection.
+class AdminReturnRequestsPage extends StatefulWidget {
+  const AdminReturnRequestsPage({super.key});
+
+  @override
+  State<AdminReturnRequestsPage> createState() =>
+      _AdminReturnRequestsPageState();
+}
+
+class _AdminReturnRequestsPageState extends State<AdminReturnRequestsPage> {
+  late Future<List<Map<String, dynamic>>> _returnsFuture;
+  final Set<String> _loadingIds = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _returnsFuture = _fetchReturningRequests();
+  }
+
+  Future<List<Map<String, dynamic>>> _fetchReturningRequests() async {
+    final response = await getIt<Dio>().get(ApiConstants.getAllBookRequests);
+    final data = response.data;
+
+    List<dynamic> allRequests = [];
+    if (data is Map<String, dynamic>) {
+      allRequests = (data['bookRequests'] ??
+          data['requests'] ??
+          data['data'] ??
+          []) as List<dynamic>;
+    } else if (data is List) {
+      allRequests = data;
+    }
+
+    return allRequests
+        .where((r) => (r['status'] as String?)?.toLowerCase() == 'returning')
+        .map((r) => r as Map<String, dynamic>)
+        .toList();
+  }
+
+  void _refresh() {
+    setState(() {
+      _returnsFuture = _fetchReturningRequests();
+    });
+  }
+
+  Future<void> _markReceived(String requestId) async {
+    setState(() => _loadingIds.add('$requestId-receive'));
+    try {
+      await getIt<Dio>().patch(
+        ApiConstants.returnRequestReceive(requestId),
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Marked as received'),
+          backgroundColor: AppColors.primary,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      _refresh();
+    } on DioException catch (e) {
+      if (!mounted) return;
+      final msg =
+          (e.response?.data is Map ? e.response?.data['message'] : null) ??
+              'Failed to mark as received';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(msg.toString()),
+          backgroundColor: Colors.redAccent,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _loadingIds.remove('$requestId-receive'));
+    }
+  }
+
+  Future<void> _completeInspection(String requestId) async {
+    setState(() => _loadingIds.add('$requestId-inspect'));
+    try {
+      await getIt<Dio>().patch(
+        ApiConstants.returnRequestInspect(requestId),
+        data: {'condition': 'good'},
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Inspection completed'),
+          backgroundColor: AppColors.primary,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      _refresh();
+    } on DioException catch (e) {
+      if (!mounted) return;
+      final msg =
+          (e.response?.data is Map ? e.response?.data['message'] : null) ??
+              'Failed to complete inspection';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(msg.toString()),
+          backgroundColor: Colors.redAccent,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    } finally {
+      if (mounted) setState(() => _loadingIds.remove('$requestId-inspect'));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        elevation: 0,
+        surfaceTintColor: Colors.transparent,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text(
+          'Return Requests',
+          style: TextStyle(
+            color: Color(0xFF052E44),
+            fontWeight: FontWeight.bold,
+            fontSize: 18,
+          ),
+        ),
+        centerTitle: true,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh, color: Color(0xFF052E44)),
+            onPressed: _refresh,
+            tooltip: 'Refresh',
+          ),
+        ],
+      ),
+      body: FutureBuilder<List<Map<String, dynamic>>>(
+        future: _returnsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(color: AppColors.primary),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.error_outline, size: 48, color: Colors.grey),
+                  const SizedBox(height: 12),
+                  const Text(
+                    'Failed to load return requests',
+                    style: TextStyle(color: Colors.grey),
+                  ),
+                  const SizedBox(height: 12),
+                  ElevatedButton.icon(
+                    onPressed: _refresh,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Retry'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.primary,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          final returns = snapshot.data ?? [];
+          if (returns.isEmpty) {
+            return const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.replay_outlined, size: 48, color: Colors.grey),
+                  SizedBox(height: 12),
+                  Text(
+                    'No pending return requests',
+                    style: TextStyle(fontSize: 15, color: Colors.grey),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return ListView.separated(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+            itemCount: returns.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 10),
+            itemBuilder: (context, index) {
+              final request = returns[index];
+              return _ReturnRequestCard(
+                request: request,
+                isReceiveLoading:
+                    _loadingIds.contains('${request['_id']}-receive'),
+                isInspectLoading:
+                    _loadingIds.contains('${request['_id']}-inspect'),
+                onMarkReceived: () => _markReceived(request['_id'] as String),
+                onCompleteInspection: () =>
+                    _completeInspection(request['_id'] as String),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ReturnRequestCard extends StatelessWidget {
+  final Map<String, dynamic> request;
+  final bool isReceiveLoading;
+  final bool isInspectLoading;
+  final VoidCallback onMarkReceived;
+  final VoidCallback onCompleteInspection;
+
+  const _ReturnRequestCard({
+    required this.request,
+    required this.isReceiveLoading,
+    required this.isInspectLoading,
+    required this.onMarkReceived,
+    required this.onCompleteInspection,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final bookTitle =
+        (request['bookTitle'] ?? request['book']?['title'] ?? 'Unknown Book')
+            .toString();
+    final userName =
+        (request['userName'] ?? request['user']?['name'] ?? 'Unknown User')
+            .toString();
+    final returnMethod =
+        (request['returnMethod'] ?? request['fulfillmentMethod'] ?? '—')
+            .toString();
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).cardColor,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: const Color(0xFFE0E0E0)),
+      ),
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Book title
+          Text(
+            bookTitle,
+            style: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.bold,
+              color: Color(0xFF052E44),
+            ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 4),
+
+          // User name
+          Row(
+            children: [
+              const Icon(Icons.person_outline,
+                  size: 14, color: Color(0xFF888888)),
+              const SizedBox(width: 4),
+              Text(
+                userName,
+                style: const TextStyle(fontSize: 13, color: Color(0xFF555555)),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+
+          // Return method
+          Row(
+            children: [
+              const Icon(Icons.local_shipping_outlined,
+                  size: 14, color: Color(0xFF888888)),
+              const SizedBox(width: 4),
+              Text(
+                'Return method: ${_capitalize(returnMethod)}',
+                style: const TextStyle(fontSize: 12, color: Color(0xFF888888)),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+
+          // Action buttons
+          Row(
+            children: [
+              Expanded(
+                child: _ActionButton(
+                  label: 'Mark Received',
+                  isLoading: isReceiveLoading,
+                  color: const Color(0xFF2196F3),
+                  onPressed: onMarkReceived,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: _ActionButton(
+                  label: 'Complete Inspection',
+                  isLoading: isInspectLoading,
+                  color: AppColors.primary,
+                  onPressed: onCompleteInspection,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _capitalize(String s) {
+    if (s.isEmpty) return s;
+    return s[0].toUpperCase() + s.substring(1).toLowerCase();
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  final String label;
+  final bool isLoading;
+  final Color color;
+  final VoidCallback onPressed;
+
+  const _ActionButton({
+    required this.label,
+    required this.isLoading,
+    required this.color,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 36,
+      child: ElevatedButton(
+        onPressed: isLoading ? null : onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          elevation: 0,
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(8),
+          ),
+        ),
+        child: isLoading
+            ? const SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: Colors.white,
+                ),
+              )
+            : Text(
+                label,
+                style: const TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
+              ),
+      ),
+    );
+  }
+}

--- a/lib/features/book_request/presentation/pages/admin_upcoming_pickups_page.dart
+++ b/lib/features/book_request/presentation/pages/admin_upcoming_pickups_page.dart
@@ -24,9 +24,9 @@ class _AdminUpcomingPickupsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(

--- a/lib/features/book_request/presentation/pages/approved_book_request_page.dart
+++ b/lib/features/book_request/presentation/pages/approved_book_request_page.dart
@@ -62,9 +62,9 @@ class _ApprovedBookRequestPageState extends State<ApprovedBookRequestPage> {
     final req = widget.request;
 
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: AppColors.textPrimary),

--- a/lib/features/book_request/presentation/pages/book_detail_page.dart
+++ b/lib/features/book_request/presentation/pages/book_detail_page.dart
@@ -10,6 +10,7 @@ import '../../../audiobook/domain/entities/audiobook.dart';
 import '../../../bookcrud/domain/entities/book_variant_entity.dart';
 import '../../../bookcrud/domain/respository/variant_repository.dart';
 import '../../../profile/presentation/blocs/profile_bloc.dart';
+import '../../../reviews/presentation/widgets/book_reviews_section.dart';
 import '../../data/datasources/book_request_remote_datasource.dart';
 import '../bloc/book_request_bloc.dart';
 import '../bloc/book_request_event.dart';
@@ -49,7 +50,6 @@ class _BookDetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-
       body: BlocConsumer<BookRequestBloc, BookRequestState>(
         listenWhen: (_, current) => current is BookRequestError,
         listener: (context, state) {
@@ -148,6 +148,11 @@ class _BookDetailContent extends StatelessWidget {
           _AboutSection(book: book),
           const SizedBox(height: 12),
           _HighlightSection(book: book),
+          const SizedBox(height: 24),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: BookReviewsSection(bookId: book.id),
+          ),
           const SizedBox(height: 24),
         ],
       ),

--- a/lib/features/book_request/presentation/pages/book_detail_page.dart
+++ b/lib/features/book_request/presentation/pages/book_detail_page.dart
@@ -49,7 +49,7 @@ class _BookDetailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: BlocConsumer<BookRequestBloc, BookRequestState>(
         listenWhen: (_, current) => current is BookRequestError,
         listener: (context, state) {

--- a/lib/features/book_request/presentation/pages/book_order_page.dart
+++ b/lib/features/book_request/presentation/pages/book_order_page.dart
@@ -87,9 +87,9 @@ class _BookOrderViewState extends State<_BookOrderView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(

--- a/lib/features/book_request/presentation/pages/book_request_form_page.dart
+++ b/lib/features/book_request/presentation/pages/book_request_form_page.dart
@@ -267,9 +267,9 @@ class _BookRequestFormPageState extends State<BookRequestFormPage> {
         },
         builder: (context, state) {
           return Scaffold(
-            backgroundColor: Colors.white,
+      
             appBar: AppBar(
-              backgroundColor: Colors.white,
+        
               elevation: 0,
               leading: IconButton(
                 icon:

--- a/lib/features/book_request/presentation/pages/book_request_success_page.dart
+++ b/lib/features/book_request/presentation/pages/book_request_success_page.dart
@@ -18,9 +18,9 @@ class BookRequestSuccessPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),

--- a/lib/features/book_request/presentation/pages/collect_from_library_page.dart
+++ b/lib/features/book_request/presentation/pages/collect_from_library_page.dart
@@ -313,9 +313,9 @@ class _CollectFromLibraryViewState extends State<_CollectFromLibraryView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(

--- a/lib/features/book_request/presentation/pages/delivered_request_detail_page.dart
+++ b/lib/features/book_request/presentation/pages/delivered_request_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:read_buddy_app/core/theme/app_colors.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../domain/entities/book_request_entity.dart';
+import '../widgets/shipment_tracking_widget.dart';
 import 'collect_from_library_page.dart';
 
 class DeliveredRequestDetailPage extends StatefulWidget {
@@ -21,9 +22,7 @@ class _DeliveredRequestDetailPageState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-
       appBar: AppBar(
-  
         elevation: 0,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(
@@ -142,6 +141,11 @@ class _DeliveredRequestDetailPageState
               const SizedBox(height: 4),
               _InfoRow('Delivery Address', widget.request.deliveryAddress!),
             ],
+
+            // Shipment tracking — shown for shipping/delivered/returning
+            if (['shipping', 'delivered', 'returning']
+                .contains(widget.request.status.toLowerCase()))
+              ShipmentTrackingWidget(requestId: widget.request.id),
 
             const SizedBox(height: 16),
 

--- a/lib/features/book_request/presentation/pages/delivered_request_detail_page.dart
+++ b/lib/features/book_request/presentation/pages/delivered_request_detail_page.dart
@@ -21,9 +21,9 @@ class _DeliveredRequestDetailPageState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         surfaceTintColor: Colors.transparent,
         leading: IconButton(

--- a/lib/features/book_request/presentation/pages/my_requests_page.dart
+++ b/lib/features/book_request/presentation/pages/my_requests_page.dart
@@ -64,7 +64,7 @@ class _MyRequestsViewState extends State<_MyRequestsView>
     return Scaffold(
       backgroundColor: const Color(0xFFFDFDFD),
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),

--- a/lib/features/book_request/presentation/widgets/shipment_tracking_widget.dart
+++ b/lib/features/book_request/presentation/widgets/shipment_tracking_widget.dart
@@ -1,0 +1,329 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:read_buddy_app/core/di/injection.dart';
+import 'package:read_buddy_app/core/network/api_constants.dart';
+import 'package:read_buddy_app/core/theme/app_colors.dart';
+
+/// Lightweight widget that fetches and displays shipment tracking info
+/// for a given book request. Shows nothing if no shipment exists (404).
+class ShipmentTrackingWidget extends StatefulWidget {
+  final String requestId;
+
+  const ShipmentTrackingWidget({super.key, required this.requestId});
+
+  @override
+  State<ShipmentTrackingWidget> createState() => _ShipmentTrackingWidgetState();
+}
+
+class _ShipmentTrackingWidgetState extends State<ShipmentTrackingWidget> {
+  late final Future<Map<String, dynamic>?> _shipmentFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _shipmentFuture = _fetchShipment();
+  }
+
+  Future<Map<String, dynamic>?> _fetchShipment() async {
+    try {
+      final response = await getIt<Dio>().get(
+        ApiConstants.shipmentByRequest(widget.requestId),
+      );
+      if (response.statusCode == 200 && response.data != null) {
+        return response.data as Map<String, dynamic>;
+      }
+      return null;
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) return null;
+      rethrow;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Map<String, dynamic>?>(
+      future: _shipmentFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8),
+            child: Center(
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: AppColors.primary,
+                ),
+              ),
+            ),
+          );
+        }
+
+        if (!snapshot.hasData || snapshot.data == null) {
+          return const SizedBox.shrink();
+        }
+
+        final shipment = snapshot.data!;
+        return _buildShipmentCard(context, shipment);
+      },
+    );
+  }
+
+  Widget _buildShipmentCard(
+    BuildContext context,
+    Map<String, dynamic> shipment,
+  ) {
+    final carrier = shipment['carrier'] as String? ?? 'Unknown';
+    final trackingNumber = shipment['trackingNumber'] as String? ?? '—';
+    final status = shipment['status'] as String? ?? 'unknown';
+    final estimatedDelivery = shipment['estimatedDelivery'] as String?;
+    final receiptImageUrl = shipment['receiptImageUrl'] as String?;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        const Text(
+          'Shipment Tracking',
+          style: TextStyle(
+            fontSize: 14,
+            fontWeight: FontWeight.bold,
+            color: Color(0xFF052E44),
+          ),
+        ),
+        const SizedBox(height: 10),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: AppColors.primary.withValues(alpha: 0.06),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: AppColors.primary.withValues(alpha: 0.2),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Carrier
+              _ShipmentInfoRow(label: 'Carrier', value: carrier),
+              const SizedBox(height: 8),
+
+              // Tracking number (copyable)
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(
+                    width: 120,
+                    child: Text(
+                      'Tracking #',
+                      style: TextStyle(fontSize: 12, color: Color(0xFF888888)),
+                    ),
+                  ),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {
+                        Clipboard.setData(ClipboardData(text: trackingNumber));
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(
+                            content: Text('Tracking number copied'),
+                            duration: Duration(seconds: 2),
+                            behavior: SnackBarBehavior.floating,
+                          ),
+                        );
+                      },
+                      child: Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              trackingNumber,
+                              style: const TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w600,
+                                color: Color(0xFF052E44),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 4),
+                          const Icon(
+                            Icons.copy,
+                            size: 14,
+                            color: Color(0xFF888888),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+
+              // Status badge
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const SizedBox(
+                    width: 120,
+                    child: Text(
+                      'Status',
+                      style: TextStyle(fontSize: 12, color: Color(0xFF888888)),
+                    ),
+                  ),
+                  _StatusBadge(status: status),
+                ],
+              ),
+
+              // Estimated delivery
+              if (estimatedDelivery != null &&
+                  estimatedDelivery.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                _ShipmentInfoRow(
+                  label: 'Est. Delivery',
+                  value: _formatDate(estimatedDelivery),
+                ),
+              ],
+
+              // Receipt image
+              if (receiptImageUrl != null && receiptImageUrl.isNotEmpty) ...[
+                const SizedBox(height: 12),
+                const Text(
+                  'Receipt',
+                  style: TextStyle(fontSize: 12, color: Color(0xFF888888)),
+                ),
+                const SizedBox(height: 6),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: CachedNetworkImage(
+                    imageUrl: receiptImageUrl,
+                    height: 120,
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                    placeholder: (_, __) => Container(
+                      height: 120,
+                      color: const Color(0xFFF0F0F0),
+                      child: const Center(
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                    errorWidget: (_, __, ___) => Container(
+                      height: 120,
+                      color: const Color(0xFFF0F0F0),
+                      child: const Center(
+                        child: Icon(Icons.broken_image, color: Colors.grey),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        const SizedBox(height: 16),
+      ],
+    );
+  }
+
+  String _formatDate(String dateStr) {
+    try {
+      final dt = DateTime.parse(dateStr);
+      const months = [
+        'Jan',
+        'Feb',
+        'Mar',
+        'Apr',
+        'May',
+        'Jun',
+        'Jul',
+        'Aug',
+        'Sep',
+        'Oct',
+        'Nov',
+        'Dec',
+      ];
+      return '${dt.day} ${months[dt.month - 1]} ${dt.year}';
+    } catch (_) {
+      return dateStr;
+    }
+  }
+}
+
+class _ShipmentInfoRow extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _ShipmentInfoRow({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 120,
+          child: Text(
+            label,
+            style: const TextStyle(fontSize: 12, color: Color(0xFF888888)),
+          ),
+        ),
+        Expanded(
+          child: Text(
+            value,
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Color(0xFF052E44),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  final String status;
+
+  const _StatusBadge({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    Color color;
+    switch (status.toLowerCase()) {
+      case 'delivered':
+        color = const Color(0xFF4CAF50);
+      case 'in_transit':
+      case 'shipping':
+        color = const Color(0xFF2196F3);
+      case 'out_for_delivery':
+        color = const Color(0xFF009688);
+      case 'returned':
+        color = const Color(0xFF9C27B0);
+      default:
+        color = const Color(0xFFFF9800);
+    }
+
+    final label = status.replaceAll('_', ' ');
+    final displayLabel =
+        label.isNotEmpty ? label[0].toUpperCase() + label.substring(1) : status;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: color.withValues(alpha: 0.4)),
+      ),
+      child: Text(
+        displayLabel,
+        style: TextStyle(
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+          color: color,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/bookcrud/presentation/pages/books_list_page.dart
+++ b/lib/features/bookcrud/presentation/pages/books_list_page.dart
@@ -57,9 +57,9 @@ class _BooksListPageState extends State<BooksListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         title: const Text('Books'),
         centerTitle: true,
       ),

--- a/lib/features/bookcrud/presentation/pages/deletecrud_book.dart
+++ b/lib/features/bookcrud/presentation/pages/deletecrud_book.dart
@@ -8,7 +8,7 @@ class DeletecrudBook {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: Colors.white,
+  
         content: const Text(
           "Are you sure you want to permanently delete this book from the ReadBuddy app?",
           style: TextStyle(fontSize: 18),

--- a/lib/features/books/presentation/pages/book_page.dart
+++ b/lib/features/books/presentation/pages/book_page.dart
@@ -158,7 +158,7 @@ class _BookPageState extends State<BookPage> {
                       color: isSelected ? Colors.green : Colors.grey.shade300,
                     ),
                   ),
-                  backgroundColor: Colors.white,
+            
                   labelStyle: TextStyle(
                     color: isSelected ? Colors.green : Colors.black,
                   ),

--- a/lib/features/category_crud/presentation/pages/category_list_page.dart
+++ b/lib/features/category_crud/presentation/pages/category_list_page.dart
@@ -123,7 +123,7 @@ class _CategoryListPageState extends State<CategoryListPage> {
     showDialog(
       context: context,
       builder: (ctx) => AlertDialog(
-        backgroundColor: Colors.white,
+  
         title: const Text(
           'Delete Category',
           style:

--- a/lib/features/category_crud/presentation/pages/delete_category.dart
+++ b/lib/features/category_crud/presentation/pages/delete_category.dart
@@ -7,7 +7,7 @@ class DeleteCategory {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        backgroundColor: Colors.white,
+  
         content: const Text(
           "Are you sure you want to permanently delete this book from the ReadBuddy app?",
           style: TextStyle(fontSize: 15),

--- a/lib/features/category_crud/presentation/widgets/category_form_widget.dart
+++ b/lib/features/category_crud/presentation/widgets/category_form_widget.dart
@@ -52,9 +52,9 @@ class _CategoryFormWidgetState extends State<CategoryFormWidget> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),

--- a/lib/features/dashboard/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/admin_dashboard_screen.dart
@@ -1,4 +1,7 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:read_buddy_app/core/di/injection.dart';
+import 'package:read_buddy_app/core/network/api_constants.dart';
 import 'package:read_buddy_app/core/theme/app_colors.dart';
 import 'package:read_buddy_app/features/profile/presentation/pages/screen/profile_screen.dart';
 import '../widgets/dashboard_box_widget.dart';
@@ -44,8 +47,33 @@ class _AdminDashboardScreenState extends State<AdminDashboardScreen> {
   }
 }
 
-class _AdminDashboardBody extends StatelessWidget {
+class _AdminDashboardBody extends StatefulWidget {
   const _AdminDashboardBody();
+
+  @override
+  State<_AdminDashboardBody> createState() => _AdminDashboardBodyState();
+}
+
+class _AdminDashboardBodyState extends State<_AdminDashboardBody> {
+  late Future<Map<String, int>> _countsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _countsFuture = _fetchDashboardCounts();
+  }
+
+  Future<Map<String, int>> _fetchDashboardCounts() async {
+    final response = await getIt<Dio>().get(ApiConstants.dashboardCounts);
+    final data = response.data as Map<String, dynamic>;
+    return {
+      'books': (data['books'] as num?)?.toInt() ?? 0,
+      'users': (data['users'] as num?)?.toInt() ?? 0,
+      'categories': (data['categories'] as num?)?.toInt() ?? 0,
+      'donations': (data['donations'] as num?)?.toInt() ?? 0,
+      'requests': (data['requests'] as num?)?.toInt() ?? 0,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -61,136 +89,182 @@ class _AdminDashboardBody extends StatelessWidget {
           ),
         ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const TextField(
-              decoration: InputDecoration(
-                prefixIcon: Icon(Icons.search),
-                hintText: 'Search',
-                border: OutlineInputBorder(),
-              ),
-            ),
-            const SizedBox(height: 16),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      body: FutureBuilder<Map<String, int>>(
+        future: _countsFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(
+              child: CircularProgressIndicator(color: Color(0xFF2CE07F)),
+            );
+          }
+
+          if (snapshot.hasError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  DashboardBoxWidget(
-                    title: 'Books Donated',
-                    count: 5,
-                    color: Colors.grey,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/admin-donations');
-                    },
+                  const Icon(Icons.error_outline, size: 48, color: Colors.grey),
+                  const SizedBox(height: 12),
+                  const Text(
+                    'Failed to load dashboard data',
+                    style: TextStyle(color: Colors.grey),
                   ),
-                  DashboardBoxWidget(
-                    title: 'Books Request',
-                    count: 8,
-                    color: Colors.redAccent,
+                  const SizedBox(height: 12),
+                  ElevatedButton.icon(
                     onPressed: () {
-                      Navigator.of(context).pushNamed('/admin-book-requests');
+                      setState(() {
+                        _countsFuture = _fetchDashboardCounts();
+                      });
                     },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'New Users',
-                    count: 5,
-                    color: Colors.lightBlue,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/admin-users');
-                    },
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Retry'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: const Color(0xFF2CE07F),
+                      foregroundColor: Colors.white,
+                    ),
                   ),
                 ],
               ),
+            );
+          }
+
+          final counts = snapshot.data!;
+          return _buildDashboardContent(counts);
+        },
+      ),
+    );
+  }
+
+  Widget _buildDashboardContent(Map<String, int> counts) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const TextField(
+            decoration: InputDecoration(
+              prefixIcon: Icon(Icons.search),
+              hintText: 'Search',
+              border: OutlineInputBorder(),
             ),
-            const SizedBox(height: 16),
-            Expanded(
-              child: GridView.count(
-                crossAxisCount: 2,
-                childAspectRatio: 0.85,
-                mainAxisSpacing: 12,
-                crossAxisSpacing: 12,
-                children: [
-                  DashboardBoxWidget(
-                    title: 'Categories',
-                    count: 12,
-                    icon: Icons.category,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/category');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Books',
-                    count: 236,
-                    icon: Icons.book,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/books');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Donations',
-                    count: 318,
-                    icon: Icons.card_giftcard,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/donated-books');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Request',
-                    count: 12,
-                    icon: Icons.list_alt,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/admin-book-requests');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Users',
-                    count: 12,
-                    icon: Icons.people,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/admin-users');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Banner',
-                    count: 12,
-                    icon: Icons.image,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/banner');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Questions',
-                    count: 0,
-                    icon: Icons.quiz,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/questions');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Upcoming Pickups',
-                    count: 0,
-                    icon: Icons.local_shipping_outlined,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/admin-book-requests');
-                    },
-                  ),
-                  DashboardBoxWidget(
-                    title: 'Libraries',
-                    count: 0,
-                    icon: Icons.local_library,
-                    onPressed: () {
-                      Navigator.of(context).pushNamed('/libraries');
-                    },
-                  ),
-                ],
-              ),
+          ),
+          const SizedBox(height: 16),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                DashboardBoxWidget(
+                  title: 'Books Donated',
+                  count: counts['donations'] ?? 0,
+                  color: Colors.grey,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-donations');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Books Request',
+                  count: counts['requests'] ?? 0,
+                  color: Colors.redAccent,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-book-requests');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'New Users',
+                  count: counts['users'] ?? 0,
+                  color: Colors.lightBlue,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-users');
+                  },
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: GridView.count(
+              crossAxisCount: 2,
+              childAspectRatio: 0.85,
+              mainAxisSpacing: 12,
+              crossAxisSpacing: 12,
+              children: [
+                DashboardBoxWidget(
+                  title: 'Categories',
+                  count: counts['categories'] ?? 0,
+                  icon: Icons.category,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/category');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Books',
+                  count: counts['books'] ?? 0,
+                  icon: Icons.book,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/books');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Donations',
+                  count: counts['donations'] ?? 0,
+                  icon: Icons.card_giftcard,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/donated-books');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Request',
+                  count: counts['requests'] ?? 0,
+                  icon: Icons.list_alt,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-book-requests');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Users',
+                  count: counts['users'] ?? 0,
+                  icon: Icons.people,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-users');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Banner',
+                  count: 0,
+                  icon: Icons.image,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/banner');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Questions',
+                  count: 0,
+                  icon: Icons.quiz,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/questions');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Upcoming Pickups',
+                  count: 0,
+                  icon: Icons.local_shipping_outlined,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-book-requests');
+                  },
+                ),
+                DashboardBoxWidget(
+                  title: 'Libraries',
+                  count: 0,
+                  icon: Icons.local_library,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/libraries');
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/dashboard/presentation/screens/admin_dashboard_screen.dart
+++ b/lib/features/dashboard/presentation/screens/admin_dashboard_screen.dart
@@ -261,6 +261,14 @@ class _AdminDashboardBodyState extends State<_AdminDashboardBody> {
                     Navigator.of(context).pushNamed('/libraries');
                   },
                 ),
+                DashboardBoxWidget(
+                  title: 'Returns',
+                  count: 0,
+                  icon: Icons.assignment_return,
+                  onPressed: () {
+                    Navigator.of(context).pushNamed('/admin-return-requests');
+                  },
+                ),
               ],
             ),
           ),

--- a/lib/features/dashboard/presentation/screens/admin_donation_detail_page.dart
+++ b/lib/features/dashboard/presentation/screens/admin_donation_detail_page.dart
@@ -93,9 +93,9 @@ class _AdminDonationDetailPageState extends State<AdminDonationDetailPage> {
     final size = MediaQuery.of(context).size;
 
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: _textDark),

--- a/lib/features/dashboard/presentation/screens/admin_donations_page.dart
+++ b/lib/features/dashboard/presentation/screens/admin_donations_page.dart
@@ -172,9 +172,9 @@ class _AdminDonationsPageState extends State<AdminDonationsPage>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),

--- a/lib/features/donate/presentation/pages/book_donation_page.dart
+++ b/lib/features/donate/presentation/pages/book_donation_page.dart
@@ -104,7 +104,6 @@ class _DonationPageState extends State<_DonationPageContent> {
 
   static const _primaryGreen = Color(0xFF2CE07F);
   static const _textDark = Color(0xFF052E44);
-  static const _background = Color(0xFFFDFDFD);
   static const _conditions = ['New', 'Like New', 'Good', 'Old', 'Other'];
 
   @override
@@ -269,7 +268,7 @@ class _DonationPageState extends State<_DonationPageContent> {
         return StatefulBuilder(
           builder: (context, setDialogState) {
             return Dialog(
-              backgroundColor: Colors.white,
+        
               elevation: 8,
               insetPadding:
                   const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
@@ -492,9 +491,9 @@ class _DonationPageState extends State<_DonationPageContent> {
     final paddingH = size.width * 0.05;
 
     return Scaffold(
-      backgroundColor: _background,
+      // backgroundColor handled by theme
       appBar: AppBar(
-        backgroundColor: _background,
+        // backgroundColor handled by theme
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: _textDark),

--- a/lib/features/donated_books/presentation/pages/donated_book_detail_page.dart
+++ b/lib/features/donated_books/presentation/pages/donated_book_detail_page.dart
@@ -15,9 +15,9 @@ class DonatedBookDetailPage extends StatelessWidget {
     final size = MediaQuery.of(context).size;
 
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: _textDark),

--- a/lib/features/donated_books/presentation/pages/donated_books_page.dart
+++ b/lib/features/donated_books/presentation/pages/donated_books_page.dart
@@ -22,9 +22,9 @@ class _DonatedBooksPageState extends State<DonatedBooksPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       appBar: AppBar(
-        backgroundColor: Colors.white,
+  
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Color(0xFF052E44)),

--- a/lib/features/profile/presentation/pages/screen/profile_screen.dart
+++ b/lib/features/profile/presentation/pages/screen/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_picker/image_picker.dart';
 import '../../../../../core/di/injection.dart';
 import '../../../../../core/network/api_constants.dart';
 import '../../../../../core/services/app_preferences.dart';
@@ -45,6 +46,70 @@ class _ProfileView extends StatelessWidget {
         },
       ),
     );
+  }
+
+  Future<void> _pickAndUploadPhoto(BuildContext context) async {
+    final picker = ImagePicker();
+    final pickedFile = await picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 800,
+      maxHeight: 800,
+      imageQuality: 80,
+    );
+    if (pickedFile == null) return;
+    if (!context.mounted) return;
+
+    // Show uploading indicator
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Row(
+          children: [
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: Colors.white,
+              ),
+            ),
+            SizedBox(width: 12),
+            Text('Uploading photo...'),
+          ],
+        ),
+        duration: Duration(seconds: 10),
+      ),
+    );
+
+    try {
+      final dio = getIt<Dio>();
+      final formData = FormData.fromMap({
+        'profileImage': await MultipartFile.fromFile(
+          pickedFile.path,
+          filename: pickedFile.name,
+        ),
+      });
+      await dio.post(ApiConstants.uploadProfileImage, data: formData);
+
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Profile photo updated successfully!'),
+          backgroundColor: Color(0xFF00C853),
+        ),
+      );
+      // Refresh profile to show updated image
+      context.read<ProfileBloc>().add(LoadProfileEvent());
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Failed to upload photo. Please try again.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
   }
 
   void _showLogoutDialog(BuildContext context) {
@@ -234,22 +299,69 @@ class _ProfileView extends StatelessWidget {
       BuildContext context, ProfileUser user, bool isUpdating) {
     return Column(
       children: [
-        _buildAvatarCircle(user, isUpdating),
+        GestureDetector(
+          onTap: isUpdating ? null : () => _pickAndUploadPhoto(context),
+          child: Stack(
+            children: [
+              _buildAvatarCircle(user, isUpdating),
+              Positioned(
+                bottom: 0,
+                right: 0,
+                child: Container(
+                  padding: const EdgeInsets.all(6),
+                  decoration: const BoxDecoration(
+                    color: _green,
+                    shape: BoxShape.circle,
+                  ),
+                  child: const Icon(
+                    Icons.camera_alt,
+                    color: Colors.white,
+                    size: 16,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
         const SizedBox(height: 12),
-        OutlinedButton.icon(
-          onPressed: isUpdating ? null : () => _showAvatarSheet(context, user),
-          icon: const Icon(Icons.face, color: _green, size: 18),
-          label: const Text(
-            'Change Avatar',
-            style: TextStyle(color: _green, fontSize: 13),
-          ),
-          style: OutlinedButton.styleFrom(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            side: const BorderSide(color: _green),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            OutlinedButton.icon(
+              onPressed:
+                  isUpdating ? null : () => _showAvatarSheet(context, user),
+              icon: const Icon(Icons.face, color: _green, size: 18),
+              label: const Text(
+                'Change Avatar',
+                style: TextStyle(color: _green, fontSize: 13),
+              ),
+              style: OutlinedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                side: const BorderSide(color: _green),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
             ),
-          ),
+            const SizedBox(width: 8),
+            OutlinedButton.icon(
+              onPressed: isUpdating ? null : () => _pickAndUploadPhoto(context),
+              icon: const Icon(Icons.photo_library, color: _green, size: 18),
+              label: const Text(
+                'Upload Photo',
+                style: TextStyle(color: _green, fontSize: 13),
+              ),
+              style: OutlinedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                side: const BorderSide(color: _green),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ),
+            ),
+          ],
         ),
       ],
     );

--- a/lib/features/profile/presentation/pages/screen/profile_screen.dart
+++ b/lib/features/profile/presentation/pages/screen/profile_screen.dart
@@ -1,7 +1,11 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../../core/di/injection.dart';
+import '../../../../../core/network/api_constants.dart';
+import '../../../../../core/services/app_preferences.dart';
+import '../../../../../core/utils/secure_storage_utils.dart';
 import '../../../../home/presentation/screens/home_screen.dart';
 import '../../../domain/entities/avatar_user_model.dart';
 import '../../../domain/entities/user_profile.dart';
@@ -62,8 +66,20 @@ class _ProfileView extends StatelessWidget {
                             Colors.grey)),
           ),
           TextButton(
-            onPressed: () {
+            onPressed: () async {
               Navigator.pop(dialogContext);
+              // Call server logout to invalidate session
+              try {
+                final dio = getIt<Dio>();
+                await dio.post(ApiConstants.logout);
+              } catch (_) {
+                // Best-effort — proceed with local logout even if API fails
+              }
+              // Clear local storage
+              final secureStorage = getIt<SecureStorageUtil>();
+              await secureStorage.clearAll();
+              await AppPreferences.clear();
+              if (!context.mounted) return;
               Navigator.of(context)
                   .pushNamedAndRemoveUntil('/signin', (_) => false);
             },

--- a/lib/features/question_crud/presentation/pages/add_edit_question_page.dart
+++ b/lib/features/question_crud/presentation/pages/add_edit_question_page.dart
@@ -144,7 +144,7 @@ class _AddEditQuestionPageState extends State<AddEditQuestionPage> {
           widget.question == null ? 'Add Question' : 'Edit Question',
           style: const TextStyle(fontWeight: FontWeight.w600),
         ),
-        backgroundColor: Colors.white,
+  
         foregroundColor: Colors.black,
         elevation: 1,
       ),

--- a/lib/features/question_crud/presentation/pages/question_list_page.dart
+++ b/lib/features/question_crud/presentation/pages/question_list_page.dart
@@ -152,7 +152,7 @@ class _QuestionListPageState extends State<QuestionListPage> {
       appBar: AppBar(
         title: const Text('Questions Management',
             style: TextStyle(fontWeight: FontWeight.w600)),
-        backgroundColor: Colors.white,
+  
         foregroundColor: Colors.black,
         elevation: 1,
       ),

--- a/lib/features/questionaries/presentations/pages/onboarding_questionaire.dart
+++ b/lib/features/questionaries/presentations/pages/onboarding_questionaire.dart
@@ -122,7 +122,7 @@ class _OnboardingQuestionnaireView extends StatelessWidget {
     final selectedAnswers = state.answers[question.id] ?? [];
 
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24),

--- a/lib/features/reviews/data/datasources/review_remote_datasource.dart
+++ b/lib/features/reviews/data/datasources/review_remote_datasource.dart
@@ -1,0 +1,124 @@
+import 'package:dio/dio.dart';
+import 'package:read_buddy_app/core/network/api_constants.dart';
+import 'package:read_buddy_app/features/reviews/data/models/review_model.dart';
+
+abstract class ReviewRemoteDataSource {
+  Future<Map<String, dynamic>> getBookReviews(String bookId);
+  Future<ReviewModel> createReview({
+    required String bookId,
+    required int rating,
+    required String comment,
+  });
+  Future<ReviewModel> updateReview({
+    required String id,
+    required int rating,
+    required String comment,
+  });
+  Future<void> deleteReview(String id);
+}
+
+class ReviewRemoteDataSourceImpl implements ReviewRemoteDataSource {
+  final Dio dio;
+
+  ReviewRemoteDataSourceImpl({required this.dio});
+
+  @override
+  Future<Map<String, dynamic>> getBookReviews(String bookId) async {
+    final response = await dio.get(ApiConstants.reviewsByBook(bookId));
+
+    if (response.statusCode != ApiConstants.success) {
+      throw Exception('Failed to load reviews: ${response.statusCode}');
+    }
+
+    final data = response.data;
+
+    if (data is Map<String, dynamic>) {
+      final reviewsList = data['reviews'] ?? [];
+      final reviews = (reviewsList as List)
+          .map((json) => ReviewModel.fromJson(json as Map<String, dynamic>))
+          .toList();
+
+      return {
+        'reviews': reviews,
+        'averageRating': (data['averageRating'] is num)
+            ? (data['averageRating'] as num).toDouble()
+            : 0.0,
+        'totalReviews': (data['totalReviews'] is num)
+            ? (data['totalReviews'] as num).toInt()
+            : reviews.length,
+      };
+    }
+
+    throw Exception('Unexpected response format');
+  }
+
+  @override
+  Future<ReviewModel> createReview({
+    required String bookId,
+    required int rating,
+    required String comment,
+  }) async {
+    final response = await dio.post(
+      ApiConstants.reviews,
+      data: {
+        'bookId': bookId,
+        'rating': rating,
+        'comment': comment,
+      },
+    );
+
+    if (response.statusCode != ApiConstants.success &&
+        response.statusCode != ApiConstants.created) {
+      throw Exception('Failed to create review: ${response.statusCode}');
+    }
+
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      // Response might have review nested under 'review' key or at root
+      final reviewData = data.containsKey('review')
+          ? data['review'] as Map<String, dynamic>
+          : data;
+      return ReviewModel.fromJson(reviewData);
+    }
+
+    throw Exception('Unexpected response format');
+  }
+
+  @override
+  Future<ReviewModel> updateReview({
+    required String id,
+    required int rating,
+    required String comment,
+  }) async {
+    final response = await dio.put(
+      ApiConstants.reviewById(id),
+      data: {
+        'rating': rating,
+        'comment': comment,
+      },
+    );
+
+    if (response.statusCode != ApiConstants.success) {
+      throw Exception('Failed to update review: ${response.statusCode}');
+    }
+
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      final reviewData = data.containsKey('review')
+          ? data['review'] as Map<String, dynamic>
+          : data;
+      return ReviewModel.fromJson(reviewData);
+    }
+
+    throw Exception('Unexpected response format');
+  }
+
+  @override
+  Future<void> deleteReview(String id) async {
+    final response = await dio.delete(ApiConstants.reviewById(id));
+
+    if (response.statusCode != ApiConstants.success) {
+      throw Exception('Failed to delete review: ${response.statusCode}');
+    }
+  }
+}

--- a/lib/features/reviews/data/models/review_model.dart
+++ b/lib/features/reviews/data/models/review_model.dart
@@ -1,0 +1,62 @@
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+
+class ReviewModel extends ReviewEntity {
+  const ReviewModel({
+    super.id,
+    required super.bookId,
+    required super.userId,
+    required super.userName,
+    required super.userAvatar,
+    required super.rating,
+    required super.comment,
+    required super.createdAt,
+    required super.updatedAt,
+  });
+
+  factory ReviewModel.fromJson(Map<String, dynamic> json) {
+    // userId can be a String (ID) or Map (populated object with _id, name, userAvatar)
+    final userData = json['userId'];
+    String userId = '';
+    String userName = '';
+    String userAvatar = '';
+
+    if (userData is Map<String, dynamic>) {
+      userId = userData['_id']?.toString() ?? '';
+      userName = userData['name']?.toString() ?? '';
+      userAvatar = userData['userAvatar']?.toString() ?? '';
+    } else if (userData is String) {
+      userId = userData;
+    }
+
+    // Fallback: some responses have user fields at root level
+    if (userName.isEmpty) {
+      userName = json['userName']?.toString() ?? '';
+    }
+    if (userAvatar.isEmpty) {
+      userAvatar = json['userAvatar']?.toString() ?? '';
+    }
+
+    return ReviewModel(
+      id: json['_id']?.toString(),
+      bookId: json['bookId']?.toString() ?? '',
+      userId: userId,
+      userName: userName,
+      userAvatar: userAvatar,
+      rating: (json['rating'] is int)
+          ? json['rating'] as int
+          : (json['rating'] as num?)?.toInt() ?? 0,
+      comment: json['comment']?.toString() ?? '',
+      createdAt: json['createdAt']?.toString() ?? '',
+      updatedAt: json['updatedAt']?.toString() ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      if (id != null) '_id': id,
+      'bookId': bookId,
+      'rating': rating,
+      'comment': comment,
+    };
+  }
+}

--- a/lib/features/reviews/data/repositories/review_repository_impl.dart
+++ b/lib/features/reviews/data/repositories/review_repository_impl.dart
@@ -1,0 +1,51 @@
+import 'package:read_buddy_app/features/reviews/data/datasources/review_remote_datasource.dart';
+import 'package:read_buddy_app/features/reviews/data/models/review_model.dart';
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+
+class ReviewRepositoryImpl implements ReviewRepository {
+  final ReviewRemoteDataSource remoteDataSource;
+
+  ReviewRepositoryImpl(this.remoteDataSource);
+
+  @override
+  Future<BookReviewsResponse> getBookReviews(String bookId) async {
+    final result = await remoteDataSource.getBookReviews(bookId);
+    return BookReviewsResponse(
+      reviews: result['reviews'] as List<ReviewModel>,
+      averageRating: result['averageRating'] as double,
+      totalReviews: result['totalReviews'] as int,
+    );
+  }
+
+  @override
+  Future<ReviewEntity> createReview({
+    required String bookId,
+    required int rating,
+    required String comment,
+  }) async {
+    return await remoteDataSource.createReview(
+      bookId: bookId,
+      rating: rating,
+      comment: comment,
+    );
+  }
+
+  @override
+  Future<ReviewEntity> updateReview({
+    required String id,
+    required int rating,
+    required String comment,
+  }) async {
+    return await remoteDataSource.updateReview(
+      id: id,
+      rating: rating,
+      comment: comment,
+    );
+  }
+
+  @override
+  Future<void> deleteReview(String id) async {
+    await remoteDataSource.deleteReview(id);
+  }
+}

--- a/lib/features/reviews/domain/entities/review_entity.dart
+++ b/lib/features/reviews/domain/entities/review_entity.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+class ReviewEntity extends Equatable {
+  final String? id;
+  final String bookId;
+  final String userId;
+  final String userName;
+  final String userAvatar;
+  final int rating;
+  final String comment;
+  final String createdAt;
+  final String updatedAt;
+
+  const ReviewEntity({
+    this.id,
+    required this.bookId,
+    required this.userId,
+    required this.userName,
+    required this.userAvatar,
+    required this.rating,
+    required this.comment,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        bookId,
+        userId,
+        userName,
+        userAvatar,
+        rating,
+        comment,
+        createdAt,
+        updatedAt,
+      ];
+}

--- a/lib/features/reviews/domain/repositories/review_repository.dart
+++ b/lib/features/reviews/domain/repositories/review_repository.dart
@@ -1,0 +1,28 @@
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+
+abstract class ReviewRepository {
+  Future<BookReviewsResponse> getBookReviews(String bookId);
+  Future<ReviewEntity> createReview({
+    required String bookId,
+    required int rating,
+    required String comment,
+  });
+  Future<ReviewEntity> updateReview({
+    required String id,
+    required int rating,
+    required String comment,
+  });
+  Future<void> deleteReview(String id);
+}
+
+class BookReviewsResponse {
+  final List<ReviewEntity> reviews;
+  final double averageRating;
+  final int totalReviews;
+
+  const BookReviewsResponse({
+    required this.reviews,
+    required this.averageRating,
+    required this.totalReviews,
+  });
+}

--- a/lib/features/reviews/domain/usecases/create_review.dart
+++ b/lib/features/reviews/domain/usecases/create_review.dart
@@ -1,0 +1,19 @@
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+
+class CreateReview {
+  final ReviewRepository repository;
+
+  CreateReview(this.repository);
+
+  Future<ReviewEntity> call({
+    required String bookId,
+    required int rating,
+    required String comment,
+  }) =>
+      repository.createReview(
+        bookId: bookId,
+        rating: rating,
+        comment: comment,
+      );
+}

--- a/lib/features/reviews/domain/usecases/delete_review.dart
+++ b/lib/features/reviews/domain/usecases/delete_review.dart
@@ -1,0 +1,9 @@
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+
+class DeleteReview {
+  final ReviewRepository repository;
+
+  DeleteReview(this.repository);
+
+  Future<void> call(String id) => repository.deleteReview(id);
+}

--- a/lib/features/reviews/domain/usecases/get_book_reviews.dart
+++ b/lib/features/reviews/domain/usecases/get_book_reviews.dart
@@ -1,0 +1,10 @@
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+
+class GetBookReviews {
+  final ReviewRepository repository;
+
+  GetBookReviews(this.repository);
+
+  Future<BookReviewsResponse> call(String bookId) =>
+      repository.getBookReviews(bookId);
+}

--- a/lib/features/reviews/domain/usecases/update_review.dart
+++ b/lib/features/reviews/domain/usecases/update_review.dart
@@ -1,0 +1,19 @@
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+
+class UpdateReview {
+  final ReviewRepository repository;
+
+  UpdateReview(this.repository);
+
+  Future<ReviewEntity> call({
+    required String id,
+    required int rating,
+    required String comment,
+  }) =>
+      repository.updateReview(
+        id: id,
+        rating: rating,
+        comment: comment,
+      );
+}

--- a/lib/features/reviews/presentation/bloc/review_bloc.dart
+++ b/lib/features/reviews/presentation/bloc/review_bloc.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:read_buddy_app/core/utils/error_handler.dart';
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+import 'package:read_buddy_app/features/reviews/domain/repositories/review_repository.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/get_book_reviews.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/create_review.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/update_review.dart';
+import 'package:read_buddy_app/features/reviews/domain/usecases/delete_review.dart';
+
+part 'review_event.dart';
+part 'review_state.dart';
+
+class ReviewBloc extends Bloc<ReviewEvent, ReviewState> {
+  final GetBookReviews _getBookReviews;
+  final CreateReview _createReview;
+  final UpdateReview _updateReview;
+  final DeleteReview _deleteReview;
+
+  ReviewBloc({
+    required GetBookReviews getBookReviews,
+    required CreateReview createReview,
+    required UpdateReview updateReview,
+    required DeleteReview deleteReview,
+  })  : _getBookReviews = getBookReviews,
+        _createReview = createReview,
+        _updateReview = updateReview,
+        _deleteReview = deleteReview,
+        super(ReviewInitial()) {
+    on<LoadBookReviews>(_onLoadBookReviews);
+    on<CreateReviewEvent>(_onCreateReview);
+    on<UpdateReviewEvent>(_onUpdateReview);
+    on<DeleteReviewEvent>(_onDeleteReview);
+  }
+
+  Future<void> _onLoadBookReviews(
+    LoadBookReviews event,
+    Emitter<ReviewState> emit,
+  ) async {
+    emit(ReviewLoading());
+    try {
+      final BookReviewsResponse response = await _getBookReviews(event.bookId);
+      emit(ReviewsLoaded(
+        reviews: response.reviews,
+        averageRating: response.averageRating,
+        totalReviews: response.totalReviews,
+      ));
+    } catch (error) {
+      emit(ReviewError(ErrorHandler.getErrorMessage(error)));
+    }
+  }
+
+  Future<void> _onCreateReview(
+    CreateReviewEvent event,
+    Emitter<ReviewState> emit,
+  ) async {
+    emit(ReviewLoading());
+    try {
+      await _createReview(
+        bookId: event.bookId,
+        rating: event.rating,
+        comment: event.comment,
+      );
+      emit(const ReviewActionSuccess('Review submitted successfully'));
+      // Reload reviews for the book
+      add(LoadBookReviews(event.bookId));
+    } catch (error) {
+      emit(ReviewError(ErrorHandler.getErrorMessage(error)));
+    }
+  }
+
+  Future<void> _onUpdateReview(
+    UpdateReviewEvent event,
+    Emitter<ReviewState> emit,
+  ) async {
+    emit(ReviewLoading());
+    try {
+      await _updateReview(
+        id: event.id,
+        rating: event.rating,
+        comment: event.comment,
+      );
+      emit(const ReviewActionSuccess('Review updated successfully'));
+      // Reload reviews for the book
+      add(LoadBookReviews(event.bookId));
+    } catch (error) {
+      emit(ReviewError(ErrorHandler.getErrorMessage(error)));
+    }
+  }
+
+  Future<void> _onDeleteReview(
+    DeleteReviewEvent event,
+    Emitter<ReviewState> emit,
+  ) async {
+    emit(ReviewLoading());
+    try {
+      await _deleteReview(event.id);
+      emit(const ReviewActionSuccess('Review deleted successfully'));
+      // Reload reviews for the book
+      add(LoadBookReviews(event.bookId));
+    } catch (error) {
+      emit(ReviewError(ErrorHandler.getErrorMessage(error)));
+    }
+  }
+}

--- a/lib/features/reviews/presentation/bloc/review_event.dart
+++ b/lib/features/reviews/presentation/bloc/review_event.dart
@@ -1,0 +1,62 @@
+part of 'review_bloc.dart';
+
+sealed class ReviewEvent extends Equatable {
+  const ReviewEvent();
+
+  @override
+  List<Object> get props => [];
+}
+
+final class LoadBookReviews extends ReviewEvent {
+  final String bookId;
+
+  const LoadBookReviews(this.bookId);
+
+  @override
+  List<Object> get props => [bookId];
+}
+
+final class CreateReviewEvent extends ReviewEvent {
+  final String bookId;
+  final int rating;
+  final String comment;
+
+  const CreateReviewEvent({
+    required this.bookId,
+    required this.rating,
+    required this.comment,
+  });
+
+  @override
+  List<Object> get props => [bookId, rating, comment];
+}
+
+final class UpdateReviewEvent extends ReviewEvent {
+  final String id;
+  final String bookId;
+  final int rating;
+  final String comment;
+
+  const UpdateReviewEvent({
+    required this.id,
+    required this.bookId,
+    required this.rating,
+    required this.comment,
+  });
+
+  @override
+  List<Object> get props => [id, bookId, rating, comment];
+}
+
+final class DeleteReviewEvent extends ReviewEvent {
+  final String id;
+  final String bookId;
+
+  const DeleteReviewEvent({
+    required this.id,
+    required this.bookId,
+  });
+
+  @override
+  List<Object> get props => [id, bookId];
+}

--- a/lib/features/reviews/presentation/bloc/review_state.dart
+++ b/lib/features/reviews/presentation/bloc/review_state.dart
@@ -1,0 +1,48 @@
+part of 'review_bloc.dart';
+
+sealed class ReviewState extends Equatable {
+  const ReviewState();
+}
+
+final class ReviewInitial extends ReviewState {
+  @override
+  List<Object> get props => [];
+}
+
+final class ReviewLoading extends ReviewState {
+  @override
+  List<Object> get props => [];
+}
+
+final class ReviewsLoaded extends ReviewState {
+  final List<ReviewEntity> reviews;
+  final double averageRating;
+  final int totalReviews;
+
+  const ReviewsLoaded({
+    required this.reviews,
+    required this.averageRating,
+    required this.totalReviews,
+  });
+
+  @override
+  List<Object> get props => [reviews, averageRating, totalReviews];
+}
+
+final class ReviewActionSuccess extends ReviewState {
+  final String message;
+
+  const ReviewActionSuccess(this.message);
+
+  @override
+  List<Object> get props => [message];
+}
+
+final class ReviewError extends ReviewState {
+  final String message;
+
+  const ReviewError(this.message);
+
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/features/reviews/presentation/widgets/book_reviews_section.dart
+++ b/lib/features/reviews/presentation/widgets/book_reviews_section.dart
@@ -1,0 +1,318 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:read_buddy_app/core/theme/app_colors.dart';
+import 'package:read_buddy_app/core/utils/secure_storage_utils.dart';
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+import 'package:read_buddy_app/features/reviews/presentation/bloc/review_bloc.dart';
+import 'package:read_buddy_app/features/reviews/presentation/widgets/review_card.dart';
+import 'package:read_buddy_app/features/reviews/presentation/widgets/review_form_widget.dart';
+
+/// A self-contained widget that shows book reviews with average rating.
+/// Embed in any book detail page with: `BookReviewsSection(bookId: bookId)`
+class BookReviewsSection extends StatelessWidget {
+  final String bookId;
+
+  const BookReviewsSection({super.key, required this.bookId});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => GetIt.instance<ReviewBloc>()..add(LoadBookReviews(bookId)),
+      child: _BookReviewsSectionContent(bookId: bookId),
+    );
+  }
+}
+
+class _BookReviewsSectionContent extends StatelessWidget {
+  final String bookId;
+
+  const _BookReviewsSectionContent({required this.bookId});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<ReviewBloc, ReviewState>(
+      listener: (context, state) {
+        if (state is ReviewActionSuccess) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: AppColors.success,
+            ),
+          );
+        } else if (state is ReviewError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: AppColors.error,
+            ),
+          );
+        }
+      },
+      builder: (context, state) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildHeader(context, state),
+            const SizedBox(height: 12),
+            _buildContent(context, state),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildHeader(BuildContext context, ReviewState state) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Row(
+          children: [
+            Text(
+              'Reviews',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: AppColors.textPrimaryColor(context),
+              ),
+            ),
+            if (state is ReviewsLoaded) ...[
+              const SizedBox(width: 8),
+              _buildAverageRatingBadge(context, state),
+            ],
+          ],
+        ),
+        TextButton.icon(
+          onPressed: () => _showReviewForm(context),
+          icon: const Icon(Icons.rate_review, size: 18),
+          label: const Text('Write Review'),
+          style: TextButton.styleFrom(
+            foregroundColor: AppColors.primary,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAverageRatingBadge(
+    BuildContext context,
+    ReviewsLoaded state,
+  ) {
+    if (state.totalReviews == 0) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: Colors.amber.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.star, size: 14, color: Colors.amber),
+          const SizedBox(width: 4),
+          Text(
+            state.averageRating.toStringAsFixed(1),
+            style: const TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: Colors.amber,
+            ),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            '(${state.totalReviews})',
+            style: TextStyle(
+              fontSize: 12,
+              color: AppColors.textMutedColor(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, ReviewState state) {
+    if (state is ReviewLoading) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(24),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (state is ReviewsLoaded) {
+      if (state.reviews.isEmpty) {
+        return _buildEmptyState(context);
+      }
+      return _buildReviewList(context, state.reviews);
+    }
+
+    if (state is ReviewError) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            children: [
+              Icon(Icons.error_outline,
+                  size: 48, color: AppColors.textMutedColor(context)),
+              const SizedBox(height: 8),
+              Text(
+                'Could not load reviews',
+                style: TextStyle(color: AppColors.textMutedColor(context)),
+              ),
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () =>
+                    context.read<ReviewBloc>().add(LoadBookReviews(bookId)),
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Icon(
+              Icons.rate_review_outlined,
+              size: 48,
+              color: AppColors.textMutedColor(context),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'No reviews yet',
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColors.textMutedColor(context),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Be the first to share your thoughts!',
+              style: TextStyle(
+                fontSize: 12,
+                color: AppColors.textMutedColor(context),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReviewList(
+    BuildContext context,
+    List<ReviewEntity> reviews,
+  ) {
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: reviews.length,
+      separatorBuilder: (_, __) => const SizedBox(height: 10),
+      itemBuilder: (context, index) {
+        final review = reviews[index];
+        return FutureBuilder<bool>(
+          future: _isReviewOwner(review.userId),
+          builder: (context, snapshot) {
+            final isOwner = snapshot.data ?? false;
+            return ReviewCard(
+              review: review,
+              isOwner: isOwner,
+              onEdit: isOwner
+                  ? () => _showReviewForm(
+                        context,
+                        reviewId: review.id,
+                        initialRating: review.rating,
+                        initialComment: review.comment,
+                      )
+                  : null,
+              onDelete:
+                  isOwner ? () => _confirmDelete(context, review.id!) : null,
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<bool> _isReviewOwner(String reviewUserId) async {
+    try {
+      final storage = GetIt.instance<SecureStorageUtil>();
+      final user = await storage.getUser();
+      return user?.id == reviewUserId;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  void _showReviewForm(
+    BuildContext context, {
+    String? reviewId,
+    int? initialRating,
+    String? initialComment,
+  }) {
+    final bloc = context.read<ReviewBloc>();
+
+    ReviewFormWidget.show(
+      context: context,
+      bookId: bookId,
+      reviewId: reviewId,
+      initialRating: initialRating,
+      initialComment: initialComment,
+      onSubmit: ({required int rating, required String comment}) {
+        if (reviewId != null) {
+          bloc.add(UpdateReviewEvent(
+            id: reviewId,
+            bookId: bookId,
+            rating: rating,
+            comment: comment,
+          ));
+        } else {
+          bloc.add(CreateReviewEvent(
+            bookId: bookId,
+            rating: rating,
+            comment: comment,
+          ));
+        }
+      },
+    );
+  }
+
+  void _confirmDelete(BuildContext context, String reviewId) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Delete Review'),
+        content: const Text(
+          'Are you sure you want to delete this review? This action cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              context.read<ReviewBloc>().add(
+                    DeleteReviewEvent(id: reviewId, bookId: bookId),
+                  );
+            },
+            style: TextButton.styleFrom(foregroundColor: AppColors.error),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/reviews/presentation/widgets/review_card.dart
+++ b/lib/features/reviews/presentation/widgets/review_card.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:read_buddy_app/core/theme/app_colors.dart';
+import 'package:read_buddy_app/features/reviews/domain/entities/review_entity.dart';
+
+class ReviewCard extends StatelessWidget {
+  final ReviewEntity review;
+  final bool isOwner;
+  final VoidCallback? onEdit;
+  final VoidCallback? onDelete;
+
+  const ReviewCard({
+    super.key,
+    required this.review,
+    this.isOwner = false,
+    this.onEdit,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppColors.cardColor(context),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.borderColor(context)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildHeader(context),
+          const SizedBox(height: 8),
+          _buildStarRating(context),
+          if (review.comment.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              review.comment,
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColors.textSecondaryColor(context),
+                height: 1.4,
+              ),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Text(
+            _formatDate(review.createdAt),
+            style: TextStyle(
+              fontSize: 12,
+              color: AppColors.textMutedColor(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 18,
+          backgroundImage: review.userAvatar.isNotEmpty
+              ? NetworkImage(review.userAvatar)
+              : null,
+          backgroundColor: AppColors.primary.withValues(alpha: 0.1),
+          child: review.userAvatar.isEmpty
+              ? Text(
+                  review.userName.isNotEmpty
+                      ? review.userName[0].toUpperCase()
+                      : '?',
+                  style: const TextStyle(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                )
+              : null,
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            review.userName.isNotEmpty ? review.userName : 'Anonymous',
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: AppColors.textPrimaryColor(context),
+            ),
+          ),
+        ),
+        if (isOwner)
+          PopupMenuButton<String>(
+            icon: Icon(
+              Icons.more_vert,
+              size: 20,
+              color: AppColors.textMutedColor(context),
+            ),
+            onSelected: (value) {
+              if (value == 'edit') onEdit?.call();
+              if (value == 'delete') onDelete?.call();
+            },
+            itemBuilder: (context) => [
+              const PopupMenuItem(
+                value: 'edit',
+                child: Row(
+                  children: [
+                    Icon(Icons.edit, size: 18),
+                    SizedBox(width: 8),
+                    Text('Edit'),
+                  ],
+                ),
+              ),
+              const PopupMenuItem(
+                value: 'delete',
+                child: Row(
+                  children: [
+                    Icon(Icons.delete, size: 18, color: AppColors.error),
+                    SizedBox(width: 8),
+                    Text('Delete', style: TextStyle(color: AppColors.error)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+      ],
+    );
+  }
+
+  Widget _buildStarRating(BuildContext context) {
+    return Row(
+      children: List.generate(5, (index) {
+        return Icon(
+          index < review.rating ? Icons.star : Icons.star_border,
+          size: 18,
+          color: index < review.rating ? Colors.amber : AppColors.textMuted,
+        );
+      }),
+    );
+  }
+
+  String _formatDate(String dateStr) {
+    final date = DateTime.tryParse(dateStr);
+    if (date == null) return '';
+
+    final now = DateTime.now();
+    final diff = now.difference(date);
+
+    if (diff.inDays >= 365) return '${(diff.inDays / 365).floor()}y ago';
+    if (diff.inDays >= 30) return '${(diff.inDays / 30).floor()}mo ago';
+    if (diff.inDays >= 1) return '${diff.inDays}d ago';
+    if (diff.inHours >= 1) return '${diff.inHours}h ago';
+    if (diff.inMinutes >= 1) return '${diff.inMinutes}m ago';
+    return 'Just now';
+  }
+}

--- a/lib/features/reviews/presentation/widgets/review_form_widget.dart
+++ b/lib/features/reviews/presentation/widgets/review_form_widget.dart
@@ -1,0 +1,235 @@
+import 'package:flutter/material.dart';
+import 'package:read_buddy_app/core/theme/app_colors.dart';
+
+class ReviewFormWidget extends StatefulWidget {
+  final String bookId;
+  final int? initialRating;
+  final String? initialComment;
+  final String? reviewId;
+  final void Function({
+    required int rating,
+    required String comment,
+  }) onSubmit;
+
+  const ReviewFormWidget({
+    super.key,
+    required this.bookId,
+    this.initialRating,
+    this.initialComment,
+    this.reviewId,
+    required this.onSubmit,
+  });
+
+  /// Show the review form as a bottom sheet
+  static Future<void> show({
+    required BuildContext context,
+    required String bookId,
+    int? initialRating,
+    String? initialComment,
+    String? reviewId,
+    required void Function({required int rating, required String comment})
+        onSubmit,
+  }) {
+    return showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: ReviewFormWidget(
+          bookId: bookId,
+          initialRating: initialRating,
+          initialComment: initialComment,
+          reviewId: reviewId,
+          onSubmit: onSubmit,
+        ),
+      ),
+    );
+  }
+
+  @override
+  State<ReviewFormWidget> createState() => _ReviewFormWidgetState();
+}
+
+class _ReviewFormWidgetState extends State<ReviewFormWidget> {
+  late int _rating;
+  late TextEditingController _commentController;
+  final _formKey = GlobalKey<FormState>();
+
+  bool get isEditing => widget.reviewId != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _rating = widget.initialRating ?? 0;
+    _commentController =
+        TextEditingController(text: widget.initialComment ?? '');
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.surfaceColor(context),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Drag handle
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppColors.borderColor(context),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Title
+            Text(
+              isEditing ? 'Edit Review' : 'Write a Review',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+                color: AppColors.textPrimaryColor(context),
+              ),
+            ),
+            const SizedBox(height: 20),
+
+            // Star rating
+            Text(
+              'Your Rating',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: AppColors.textSecondaryColor(context),
+              ),
+            ),
+            const SizedBox(height: 8),
+            _buildStarSelector(),
+            const SizedBox(height: 20),
+
+            // Comment field
+            Text(
+              'Your Review',
+              style: TextStyle(
+                fontSize: 14,
+                fontWeight: FontWeight.w500,
+                color: AppColors.textSecondaryColor(context),
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextFormField(
+              controller: _commentController,
+              maxLines: 4,
+              maxLength: 500,
+              decoration: InputDecoration(
+                hintText: 'Share your thoughts about this book...',
+                hintStyle: TextStyle(
+                  color: AppColors.textMutedColor(context),
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: AppColors.borderColor(context)),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: BorderSide(color: AppColors.borderColor(context)),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                  borderSide: const BorderSide(color: AppColors.primary),
+                ),
+                contentPadding: const EdgeInsets.all(14),
+              ),
+              validator: (value) {
+                if ((value == null || value.trim().isEmpty) && _rating == 0) {
+                  return 'Please provide a rating or comment';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 20),
+
+            // Submit button
+            SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: ElevatedButton(
+                onPressed: _onSubmit,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.primary,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(
+                  isEditing ? 'Update Review' : 'Submit Review',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStarSelector() {
+    return Row(
+      children: List.generate(5, (index) {
+        final starIndex = index + 1;
+        return GestureDetector(
+          onTap: () => setState(() => _rating = starIndex),
+          child: Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Icon(
+              starIndex <= _rating ? Icons.star : Icons.star_border,
+              size: 36,
+              color: starIndex <= _rating
+                  ? Colors.amber
+                  : AppColors.textMutedColor(context),
+            ),
+          ),
+        );
+      }),
+    );
+  }
+
+  void _onSubmit() {
+    if (_rating == 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please select a rating')),
+      );
+      return;
+    }
+
+    if (_formKey.currentState?.validate() ?? false) {
+      widget.onSubmit(
+        rating: _rating,
+        comment: _commentController.text.trim(),
+      );
+      Navigator.of(context).pop();
+    }
+  }
+}

--- a/lib/features/user_preference/presentation/screens/question_five_screen.dart
+++ b/lib/features/user_preference/presentation/screens/question_five_screen.dart
@@ -59,7 +59,7 @@ class _QuestionFiveScreenState extends State<QuestionFiveScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(

--- a/lib/features/user_preference/presentation/screens/question_four_screen.dart
+++ b/lib/features/user_preference/presentation/screens/question_four_screen.dart
@@ -43,7 +43,7 @@ class _QuestionFourScreenState extends State<QuestionFourScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(

--- a/lib/features/user_preference/presentation/screens/question_screen.dart
+++ b/lib/features/user_preference/presentation/screens/question_screen.dart
@@ -55,7 +55,7 @@ class _QuestionScreenState extends State<QuestionScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(

--- a/lib/features/user_preference/presentation/screens/question_three_screen.dart
+++ b/lib/features/user_preference/presentation/screens/question_three_screen.dart
@@ -34,7 +34,7 @@ class _QuestionThreeScreenState extends State<QuestionThreeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(

--- a/lib/features/user_preference/presentation/screens/question_two_screen.dart
+++ b/lib/features/user_preference/presentation/screens/question_two_screen.dart
@@ -44,7 +44,7 @@ class _QuestionTwoScreenState extends State<QuestionTwoScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+
       body: SafeArea(
         child: Center(
           child: ConstrainedBox(

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -3,8 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:read_buddy_app/core/di/injection.dart';
 import 'package:read_buddy_app/features/bookcrud/presentation/bloc/bloc/book_crud_bloc.dart';
 import 'package:read_buddy_app/features/bookcrud/presentation/cubit/cubit/user_cubit.dart';
-import 'package:read_buddy_app/features/settings/change_password_screen.dart';
 import 'package:read_buddy_app/features/bookcrud/presentation/cubit/cubit/location_cubit.dart';
+import 'package:read_buddy_app/features/book_request/presentation/pages/admin_return_requests_page.dart';
+import 'package:read_buddy_app/features/auth/presentation/pages/change_password_page.dart';
 import 'package:read_buddy_app/features/donate/presentation/bloc/donate_book_bloc.dart';
 import 'package:read_buddy_app/features/questionaries/presentations/bloc/on_boarding_bloc.dart';
 import 'package:read_buddy_app/features/library/presentation/pages/library_list_page.dart';
@@ -92,7 +93,10 @@ class AppRouter {
       case '/reset-password':
         return MaterialPageRoute(builder: (_) => const ResetPasswordScreen());
       case '/change-password':
-        return MaterialPageRoute(builder: (_) => const ChangePasswordScreen());
+        return MaterialPageRoute(builder: (_) => const ChangePasswordPage());
+      case '/admin-return-requests':
+        return MaterialPageRoute(
+            builder: (_) => const AdminReturnRequestsPage());
       case '/admin':
         return MaterialPageRoute(builder: (_) => const AdminDashboardScreen());
       case '/admin-users':


### PR DESCRIPTION
- Remove hardcoded 'backgroundColor: Colors.white' from 37+ pages/screens so they now inherit scaffoldBackgroundColor from the centralized theme
- Fix BUG-016: address model no longer sends redundant combined 'address' field in toJson() that caused city/state/pincode to append into line1 when loaded back from server
- Admin book request cards now use Theme.of(context).cardColor
- Book donation page no longer uses hardcoded _background constant

Modules fixed for dark mode:
- Auth (sign in, sign up, forgot password, OTP, new password, verification)
- Book Request (admin requests, pickups, approvals, orders, forms, success)
- Book CRUD (list, detail, delete)
- Banner (list, add, delete)
- Category CRUD (list, form, delete)
- Dashboard (donations, donation detail)
- Donated Books (list, detail)
- Donate (book donation page)
- Books (book page)
- Question CRUD (list, add/edit)
- Questionaries (onboarding)
- User Preference (all question screens)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied app-wide dark theme (removed hardcoded whites), fixed address parsing (BUG-016), and added reviews, shipment tracking, admin return management, and change password. Also enabled live dashboard counts, profile photo upload, improved logout, and Android build setup.

- **New Features**
  - Reviews: end-to-end (domain/data/bloc), embed with `BookReviewsSection(bookId)` in book detail; includes `ReviewBloc`, `ReviewCard`, and `ReviewFormWidget`.
  - Shipping & returns: shipment tracking widget on delivered request detail (carrier, tracking, status, ETA, receipt); new admin return requests page with receive/inspect actions and a dashboard tile.
  - Account & admin: change password page for authenticated users; live dashboard counts with loading/retry; profile photo upload with progress and auto-refresh; Android Gradle setup with `MainActivity`.

- **Bug Fixes**
  - AddressModel: corrected parsing and serialization to stop appending combined address into `addressLine1` (fixes BUG-016).
  - Logout: now calls server `logout`, then clears secure storage and preferences before redirecting.

<sup>Written for commit aca25349db18889044eeb9fd6baa5bb48c577803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kunalgharate/read-buddy-app/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Android app configuration and Flutter activity support, enabling Android builds and launches.

- **Bug Fixes**
  - Improved address handling by reliably parsing individual address fields and supporting legacy combined addresses.
  - Corrected address serialization to avoid sending redundant combined address data.

- **Style**
  - Updated screens, dialogs, cards, and controls to use the active app theme instead of fixed white backgrounds, improving consistency across display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->